### PR TITLE
Add Stunden-Idee issue template and validation workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/stunden-idee.yml
+++ b/.github/ISSUE_TEMPLATE/stunden-idee.yml
@@ -1,0 +1,38 @@
+name: "Stunden-Idee"
+description: "Schlage eine neue Stunden-Idee für das RehaSport-Projekt vor."
+title: "[Stunden-Idee] ${issue_title}"
+labels:
+  - stunden-idee
+body:
+  - type: input
+    id: issue_title
+    attributes:
+      label: "Titel"
+      description: "Wie lautet der prägnante Titel deiner Stunden-Idee?"
+      placeholder: "z.B. Balance-Training mit Theraband"
+    validations:
+      required: true
+  - type: textarea
+    id: concept
+    attributes:
+      label: "Konzept"
+      description: "Welches Konzept verfolgt die Stunde? Beschreibe Zielgruppe, Ziele und thematischen Schwerpunkt."
+      placeholder: "Beschreibe das übergreifende Konzept der Stunde."
+    validations:
+      required: true
+  - type: textarea
+    id: outline
+    attributes:
+      label: "Ablaufskizze"
+      description: "Skizziere den zeitlichen Ablauf (Aufwärmen, Hauptteil, Schwerpunkt, Ausklang) inklusive Kernübungen."
+      placeholder: "Gliedere die Stunde nach Phasen und nenne exemplarische Übungen."
+    validations:
+      required: true
+  - type: textarea
+    id: safety
+    attributes:
+      label: "Sicherheitshinweise"
+      description: "Welche Kontraindikationen, Alternativen oder Sicherheitsaspekte sind zu beachten?"
+      placeholder: "Hinweise für Teilnehmende mit Einschränkungen (Knie, Schulter etc.)."
+    validations:
+      required: true

--- a/.github/workflows/validate-stunden-idee.yml
+++ b/.github/workflows/validate-stunden-idee.yml
@@ -1,0 +1,224 @@
+name: "Validate Stunden-Idee"
+
+on:
+  issues:
+    types:
+      - opened
+      - labeled
+
+permissions:
+  contents: read
+  issues: write
+  actions: read
+
+jobs:
+  validate:
+    if: >-
+      ${{
+        (github.event.action == 'opened' && contains(github.event.issue.labels.*.name, 'stunden-idee')) ||
+        (github.event.action == 'labeled' && github.event.label.name == 'stunden-idee')
+      }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Prüfe Tageslimit für Stunden-Ideen
+        id: check_limit
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { owner, repo } = context.repo;
+            const since = new Date(Date.now() - 24 * 60 * 60 * 1000);
+            const sinceIso = since.toISOString();
+            const query = `repo:${owner}/${repo} label:stunden-idee is:issue created:>=${sinceIso}`;
+            core.info(`Suchanfrage für Limitprüfung: ${query}`);
+
+            const searchResult = await github.rest.search.issuesAndPullRequests({
+              q: query,
+            });
+
+            const total = searchResult.data.total_count;
+            core.info(`Gefundene Stunden-Ideen der letzten 24h: ${total}`);
+            const limitExceeded = total >= 5;
+            if (limitExceeded) {
+              core.info("Tageslimit erreicht – Issue wird geschlossen.");
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: context.issue.number,
+                body: "Limit erreicht: Heute wurden bereits 5 Stunden-Ideen eingereicht. Bitte versuche es morgen erneut.",
+              });
+
+              try {
+                await github.rest.issues.removeLabel({
+                  owner,
+                  repo,
+                  issue_number: context.issue.number,
+                  name: "stunden-idee",
+                });
+              } catch (error) {
+                core.warning(`Konnte Label nicht entfernen: ${error.message}`);
+              }
+
+              await github.rest.issues.update({
+                owner,
+                repo,
+                issue_number: context.issue.number,
+                state: "closed",
+              });
+            }
+
+            core.setOutput("limitExceeded", String(limitExceeded));
+      - name: KI-Validierung ausführen
+        id: ai_check
+        if: steps.check_limit.outputs.limitExceeded != 'true'
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          ISSUE_BODY: ${{ github.event.issue.body }}
+        run: |
+          echo "Arbeitsverzeichnis: $PWD";
+          echo "Erstelle KI-Payload unter: $PWD/payload.json";
+          jq -n --arg body "$ISSUE_BODY" '{
+            model: "gpt-4o-mini",
+            input: [
+              {
+                role: "system",
+                content: [
+                  {
+                    type: "text",
+                    text: "Du prüfst neue Stunden-Ideen für das RehaSport-Projekt. Antworte ausschliesslich mit einem JSON-Objekt im Format {\"status\":\"approved|changes_requested\",\"summary\":\"kurze Begründung\"}. Genehmige nur vollständige, sichere und konsistente Vorschläge."
+                  }
+                ]
+              },
+              {
+                role: "user",
+                content: [
+                  {
+                    type: "text",
+                    text: $body
+                  }
+                ]
+              }
+            ]
+          }' > payload.json
+
+          echo "Sende Anfrage an OpenAI API";
+          http_code=$(curl -sS -w '%{http_code}' -o response.json \
+            -X POST https://api.openai.com/v1/responses \
+            -H "Content-Type: application/json" \
+            -H "Authorization: Bearer $OPENAI_API_KEY" \
+            -d @payload.json)
+
+          echo "OpenAI HTTP-Status: $http_code";
+          echo "Antwort gespeichert unter: $PWD/response.json";
+          cat response.json
+
+          if [ "$http_code" -ge 400 ]; then
+            {
+              echo "response<<EOF"
+              cat response.json
+              echo "EOF"
+            } >> "$GITHUB_OUTPUT"
+            exit 1
+          fi
+
+          {
+            echo "response<<EOF"
+            cat response.json
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+      - name: KI-Antwort auswerten
+        if: steps.check_limit.outputs.limitExceeded != 'true'
+        uses: actions/github-script@v7
+        env:
+          AI_RESPONSE: ${{ steps.ai_check.outputs.response }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { owner, repo } = context.repo;
+            const responseRaw = process.env.AI_RESPONSE || '{}';
+            core.info(`Rohantwort der KI: ${responseRaw}`);
+            let responseData;
+            try {
+              responseData = JSON.parse(responseRaw);
+            } catch (error) {
+              core.warning(`Konnte JSON der Antwort nicht parsen: ${error.message}`);
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: context.issue.number,
+                body: "Bitte konkretisieren… die automatische Prüfung konnte die Antwort nicht verarbeiten.",
+              });
+              await github.rest.issues.update({
+                owner,
+                repo,
+                issue_number: context.issue.number,
+                state: "closed",
+              });
+              return;
+            }
+
+            const output = Array.isArray(responseData.output) ? responseData.output : [];
+            const text = output
+              .flatMap((entry) => Array.isArray(entry.content) ? entry.content : [])
+              .map((part) => typeof part === 'object' && part !== null ? (part.text || '') : '')
+              .join('\n')
+              .trim();
+
+            core.info(`Ausgabekanal der KI: ${text}`);
+            let parsed;
+            try {
+              parsed = JSON.parse(text);
+            } catch (error) {
+              core.warning(`Keine gültige JSON-Antwort erhalten: ${error.message}`);
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: context.issue.number,
+                body: `Bitte konkretisieren… die KI-Antwort konnte nicht ausgewertet werden. Originaltext:\n\n${text}`,
+              });
+              await github.rest.issues.update({
+                owner,
+                repo,
+                issue_number: context.issue.number,
+                state: "closed",
+              });
+              return;
+            }
+
+            const status = String(parsed.status || '').toLowerCase();
+            const summary = parsed.summary || 'Keine Begründung vorhanden.';
+            core.info(`Bewertungsstatus: ${status}`);
+            core.info(`Begründung: ${summary}`);
+
+            if (status === 'approved') {
+              await github.rest.issues.addLabels({
+                owner,
+                repo,
+                issue_number: context.issue.number,
+                labels: ['idee-validiert'],
+              });
+              core.info('Label "idee-validiert" wurde gesetzt.');
+            } else {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: context.issue.number,
+                body: `Bitte konkretisieren… ${summary}`,
+              });
+              try {
+                await github.rest.issues.removeLabel({
+                  owner,
+                  repo,
+                  issue_number: context.issue.number,
+                  name: 'stunden-idee',
+                });
+              } catch (error) {
+                core.warning(`Konnte Label nicht entfernen: ${error.message}`);
+              }
+              await github.rest.issues.update({
+                owner,
+                repo,
+                issue_number: context.issue.number,
+                state: 'closed',
+              });
+            }

--- a/README.md
+++ b/README.md
@@ -156,8 +156,16 @@ Alle Übungen einer Stunde verfolgen ein gemeinsames Ziel:
 
 Für bessere Organisation verwenden Sie Tags:
 
-**Bereich**: `#aufwärmen` `#hauptteil` `#schwerpunkt` `#ausklang`  
-**Schwerpunkt**: `#kraft` `#ausdauer` `#beweglichkeit` `#koordination` `#balance`  
+**Bereich**: `#aufwärmen` `#hauptteil` `#schwerpunkt` `#ausklang`
+**Schwerpunkt**: `#kraft` `#ausdauer` `#beweglichkeit` `#koordination` `#balance`
+
+## 💡 Stunden-Ideen einreichen
+
+Du möchtest eine neue Stunden-Idee vorschlagen? Nutze unser GitHub-Issue-Formular „Stunden-Idee“ und beschreibe Titel, Konzept, Ablaufskizze sowie alle sicherheitsrelevanten Hinweise. Nach dem Absenden prüft ein automatischer KI-Check, ob die Angaben vollständig und plausibel sind. Bei erfolgreicher Prüfung erhält dein Vorschlag das Label `idee-validiert`, andernfalls wird das Issue mit einem Hinweis „Bitte konkretisieren…“ geschlossen.
+
+Beachte bitte das Tageslimit: maximal fünf Stunden-Ideen können innerhalb von 24 Stunden eingereicht werden. Wird das Limit erreicht, informiert dich der Bot und schließt das Issue automatisch – probiere es dann am Folgetag erneut.
+
+Für die Einreichung benötigst du einen GitHub-Account, damit wir Rückfragen direkt im Issue klären können.
 **Anpassung**: `#knie-freundlich` `#schulter-freundlich` `#anfänger` `#fortgeschritten` `#senioren`  
 **Zielgruppe**: `#orthopädie` `#herz-kreislauf` `#neurologie` `#allgemein`
 

--- a/site/src/components/SubmitIdeaCard.tsx
+++ b/site/src/components/SubmitIdeaCard.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+import { getStundenIdeeUrl } from "../config";
+
+type SubmitIdeaCardProps = {
+  className?: string;
+};
+
+export const SubmitIdeaCard: React.FC<SubmitIdeaCardProps> = ({ className }) => {
+  const stundenIdeeUrl = getStundenIdeeUrl();
+
+  return (
+    <div className={["submit-idea-card", className].filter(Boolean).join(" ")}>
+      <h2>Neue Stunden-Idee?</h2>
+      <p>
+        Teile dein Konzept mit der Community und reiche es direkt über unser GitHub-Issue-Formular ein.
+      </p>
+      <a
+        className="submit-idea-card__button"
+        href={stundenIdeeUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        Stunden-Idee einreichen
+      </a>
+    </div>
+  );
+};
+
+export default SubmitIdeaCard;

--- a/site/src/config.ts
+++ b/site/src/config.ts
@@ -1,0 +1,13 @@
+export const github = {
+  /**
+   * Besitzer:in des GitHub-Repositories. Kann über NEXT_PUBLIC_GITHUB_OWNER überschrieben werden.
+   */
+  owner: process.env.NEXT_PUBLIC_GITHUB_OWNER ?? "OWNER_PLACEHOLDER",
+  /**
+   * Repository-Name. Kann über NEXT_PUBLIC_GITHUB_REPO überschrieben werden.
+   */
+  repo: process.env.NEXT_PUBLIC_GITHUB_REPO ?? "RehaSport",
+};
+
+export const getStundenIdeeUrl = () =>
+  `https://github.com/${github.owner}/${github.repo}/issues/new?template=stunden-idee.yml`;


### PR DESCRIPTION
## Summary
- add a Stunden-Idee issue form with title, concept, outline, and safety fields plus auto-labeling
- link the new submission flow from the frontend via a config-driven button
- validate incoming submissions with a rate limit, AI review workflow, and README documentation

## Testing
- not run (not applicable)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69186c0f65388333baa90239f3ffc623)