### PR TITLE
Fix TypeScript build errors and configure markdown highlighting

### DIFF
--- a/site/src/components/DetailView.tsx
+++ b/site/src/components/DetailView.tsx
@@ -4,14 +4,21 @@ import hljs from "highlight.js";
 import { REPO_BASE_URL } from "../config";
 import type { ContentEntry } from "../types";
 
-marked.setOptions({
-  highlight(code, language) {
-    if (language && hljs.getLanguage(language)) {
-      return hljs.highlight(code, { language }).value;
-    }
-    return hljs.highlightAuto(code).value;
+const renderer = new marked.Renderer();
+
+renderer.code = (code: string, infostring: string | undefined) => {
+  const language = (infostring ?? "").trim().split(/\s+/)[0];
+
+  if (language && hljs.getLanguage(language)) {
+    const { value } = hljs.highlight(code, { language });
+    return `<pre><code class="hljs language-${language}">${value}</code></pre>`;
   }
-});
+
+  const { value } = hljs.highlightAuto(code);
+  return `<pre><code class="hljs">${value}</code></pre>`;
+};
+
+marked.use({ renderer });
 
 const contentCache = new Map<string, string>();
 

--- a/site/src/config.ts
+++ b/site/src/config.ts
@@ -4,13 +4,13 @@ export const REPO_BASE_URL =
   (import.meta.env?.VITE_REPO_BASE_URL as string | undefined)?.replace(/\/?$/, "/") ?? DEFAULT_REPO_BASE_URL;
 export const github = {
   /**
-   * Besitzer:in des GitHub-Repositories. Kann über NEXT_PUBLIC_GITHUB_OWNER überschrieben werden.
+   * Besitzer:in des GitHub-Repositories. Kann über VITE_GITHUB_OWNER überschrieben werden.
    */
-  owner: process.env.NEXT_PUBLIC_GITHUB_OWNER ?? "OWNER_PLACEHOLDER",
+  owner: (import.meta.env?.VITE_GITHUB_OWNER as string | undefined) ?? "OWNER_PLACEHOLDER",
   /**
-   * Repository-Name. Kann über NEXT_PUBLIC_GITHUB_REPO überschrieben werden.
+   * Repository-Name. Kann über VITE_GITHUB_REPO überschrieben werden.
    */
-  repo: process.env.NEXT_PUBLIC_GITHUB_REPO ?? "RehaSport",
+  repo: (import.meta.env?.VITE_GITHUB_REPO as string | undefined) ?? "RehaSport",
 };
 
 export const getStundenIdeeUrl = () =>

--- a/site/tsconfig.base.json
+++ b/site/tsconfig.base.json
@@ -12,6 +12,7 @@
     "esModuleInterop": true,
     "strict": true,
     "noFallthroughCasesInSwitch": true,
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "noEmit": true
   }
 }

--- a/site/tsconfig.node.json
+++ b/site/tsconfig.node.json
@@ -5,8 +5,8 @@
     "module": "ESNext",
     "moduleResolution": "Node",
     "allowSyntheticDefaultImports": true,
-    "types": ["node"]
+    "noEmit": false
   },
-  "include": ["vite.config.ts", "scripts"],
+  "include": ["vite.config.ts", "scripts", "types.d.ts"],
   "exclude": ["src"]
 }

--- a/site/types.d.ts
+++ b/site/types.d.ts
@@ -1,0 +1,7 @@
+export {};
+
+declare global {
+  const process: {
+    env: Record<string, string | undefined>;
+  };
+}


### PR DESCRIPTION
## Summary
- update the markdown renderer to use a custom code highlighter compatible with the latest marked typings
- read repository configuration from Vite environment variables and add a local declaration for process
- prevent unwanted JavaScript emission from TypeScript builds while keeping the node config project compilable

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918bcd292bc8333b032798a8548fd4f)