### PR TITLE
Add initial Vitest setup

### DIFF
--- a/site/package.json
+++ b/site/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "preview": "vite preview",
-    "generate:content": "node ../scripts/generate-content-index.js"
+    "generate:content": "node ../scripts/generate-content-index.js",
+    "test": "vitest"
   },
   "dependencies": {
     "highlight.js": "^11.9.0",
@@ -20,6 +21,7 @@
     "@types/react-dom": "^18.2.18",
     "@vitejs/plugin-react-swc": "^3.7.0",
     "typescript": "^5.4.5",
-    "vite": "^5.2.0"
+    "vite": "^5.2.0",
+    "vitest": "^1.6.0"
   }
 }

--- a/site/src/App.test.tsx
+++ b/site/src/App.test.tsx
@@ -1,0 +1,40 @@
+import { renderToString } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+import App from "./App";
+
+type MockUseContentIndex = ReturnType<typeof vi.fn>;
+
+const mockEntries = [
+  {
+    id: "stunde-1",
+    type: "stunde" as const,
+    path: "Stunden/balance-basics.md",
+    title: "Balance Basics",
+    summary: "Stabilität verbessern",
+    concepts: ["Balance"],
+    phases: ["Phase 1"],
+    tags: ["mobilität"]
+  }
+];
+
+vi.mock("./hooks/useContentIndex", () => {
+  const useContentIndex: MockUseContentIndex = vi.fn(() => ({
+    entries: mockEntries,
+    isLoading: false,
+    error: undefined
+  }));
+
+  return { useContentIndex };
+});
+
+describe("App", () => {
+  it("rendert die Navigation und die Inhalte der aktiven Kategorie", () => {
+    const html = renderToString(<App />);
+
+    expect(html).toContain("Stunden");
+    expect(html).toContain("Übungen");
+    expect(html).toContain("Konzepte");
+    expect(html).toContain("Balance Basics");
+  });
+});

--- a/site/vite.config.ts
+++ b/site/vite.config.ts
@@ -10,5 +10,8 @@ export default defineConfig({
   base,
   server: {
     host: "0.0.0.0"
+  },
+  test: {
+    environment: "node"
   }
 });


### PR DESCRIPTION
## Summary
- add a Vitest test script and dependency to the site workspace
- configure Vite to expose a Vitest test environment
- add an initial smoke test that renders the App component

## Testing
- `npm run test` *(fails: Vitest binary is unavailable until dependencies are installed)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918bcf2d6588333b3eebbf30a40cf39)