### PR TITLE
Fix TypeScript build errors and configure markdown highlighting (follow-up)

### DIFF
--- a/site/tsconfig.base.json
+++ b/site/tsconfig.base.json
@@ -12,7 +12,6 @@
     "esModuleInterop": true,
     "strict": true,
     "noFallthroughCasesInSwitch": true,
-    "jsx": "react-jsx",
-    "noEmit": true
+    "jsx": "react-jsx"
   }
 }


### PR DESCRIPTION
## Summary
- remove the `noEmit` override from the shared base TypeScript configuration so composite projects can build successfully

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918bfb985e48333864788f7a3f2cc5e)