### PR TITLE
Fix OpenAI secret checks in validation workflow

### DIFF
--- a/.github/workflows/validate-stunden-idee.yml
+++ b/.github/workflows/validate-stunden-idee.yml
@@ -19,6 +19,8 @@ jobs:
         (github.event.action == 'labeled' && github.event.label.name == 'stunden-idee')
       }}
     runs-on: ubuntu-latest
+    env:
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
     steps:
       - name: Prüfe Tageslimit für Stunden-Ideen
         id: check_limit
@@ -70,9 +72,8 @@ jobs:
             core.setOutput("limitExceeded", String(limitExceeded));
       - name: KI-Validierung ausführen
         id: ai_check
-        if: steps.check_limit.outputs.limitExceeded != 'true' && secrets.OPENAI_API_KEY != ''
+        if: steps.check_limit.outputs.limitExceeded != 'true' && env.OPENAI_API_KEY != ''
         env:
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           ISSUE_BODY: ${{ github.event.issue.body }}
         run: |
           echo "Arbeitsverzeichnis: $PWD";
@@ -223,7 +224,7 @@ jobs:
               });
             }
       - name: Fehlende KI-Konfiguration kommunizieren
-        if: steps.check_limit.outputs.limitExceeded != 'true' && secrets.OPENAI_API_KEY == ''
+        if: steps.check_limit.outputs.limitExceeded != 'true' && env.OPENAI_API_KEY == ''
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- set the OpenAI secret as a job-level environment variable
- gate the AI validation steps using the environment variable instead of the secrets context

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918c0a0c84c8333934c4246ba1d00d7)