### PR TITLE
Fix Vitest configuration and adjust App test typing

### DIFF
--- a/site/src/App.test.tsx
+++ b/site/src/App.test.tsx
@@ -3,7 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import App from "./App";
 
-type MockUseContentIndex = ReturnType<typeof vi.fn>;
+import type { UseContentIndexResult } from "./hooks/useContentIndex";
 
 const mockEntries = [
   {
@@ -19,7 +19,7 @@ const mockEntries = [
 ];
 
 vi.mock("./hooks/useContentIndex", () => {
-  const useContentIndex: MockUseContentIndex = vi.fn(() => ({
+  const useContentIndex = vi.fn<[], UseContentIndexResult>(() => ({
     entries: mockEntries,
     isLoading: false,
     error: undefined

--- a/site/vite.config.ts
+++ b/site/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from "vite";
+import { defineConfig } from "vitest/config";
 import react from "@vitejs/plugin-react-swc";
 
 const repository = process.env.GITHUB_REPOSITORY;


### PR DESCRIPTION
## Summary
- import `defineConfig` from `vitest/config` so the Vitest `test` options stay type-safe in the Vite config
- type the `useContentIndex` mock with `UseContentIndexResult` to satisfy the Vitest mock signature

## Testing
- npm run build
- npm run test -- --run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918c0d74494833393801d2c4d252aa4)