### PR TITLE
Fix Vite base path for custom domain deployments

### DIFF
--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -13,6 +13,7 @@
         "react-router-dom": "^6.23.1"
       },
       "devDependencies": {
+        "@types/node": "^24.10.1",
         "@types/react": "^18.2.47",
         "@types/react-dom": "^18.2.18",
         "@vitejs/plugin-react-swc": "^3.7.0",
@@ -1052,6 +1053,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/node": {
+      "version": "24.10.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.1.tgz",
+      "integrity": "sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
@@ -1655,6 +1666,13 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/vite": {
       "version": "7.2.2",

--- a/site/package.json
+++ b/site/package.json
@@ -16,6 +16,7 @@
     "react-router-dom": "^6.23.1"
   },
   "devDependencies": {
+    "@types/node": "^24.10.1",
     "@types/react": "^18.2.47",
     "@types/react-dom": "^18.2.18",
     "@vitejs/plugin-react-swc": "^3.7.0",

--- a/site/tsconfig.node.json
+++ b/site/tsconfig.node.json
@@ -6,7 +6,8 @@
     "moduleResolution": "Node",
     "allowSyntheticDefaultImports": true,
     "noEmit": false,
-    "outDir": "./dist/node"
+    "outDir": "./dist/node",
+    "types": ["node"]
   },
   "include": ["vite.config.ts", "scripts", "types.d.ts"],
   "exclude": ["src"]

--- a/site/vite.config.ts
+++ b/site/vite.config.ts
@@ -1,5 +1,9 @@
+/// <reference types="node" />
+
 import { defineConfig } from "vitest/config";
 import react from "@vitejs/plugin-react-swc";
+import { existsSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 
 export default defineConfig(({ mode }) => {
   const repository = process.env.GITHUB_REPOSITORY;
@@ -8,9 +12,12 @@ export default defineConfig(({ mode }) => {
   const envBase = process.env.VITE_BASE_PATH;
   const isDev = mode === "development";
 
+  const cnamePath = fileURLToPath(new URL("./public/CNAME", import.meta.url));
+  const hasCustomDomain = existsSync(cnamePath);
+
   const base = isDev
     ? "/"
-    : envBase ?? (repositoryName ? `/${repositoryName}/` : "./");
+    : envBase ?? (hasCustomDomain ? "./" : repositoryName ? `/${repositoryName}/` : "./");
 
   return {
     plugins: [react()],


### PR DESCRIPTION
## Summary
- detect the GitHub Pages CNAME file and use a relative Vite base path so static assets resolve on custom domains
- enable Node type definitions for the Vite configuration so the build can import Node modules safely

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918c7c505208333b66b65a0abffaf6f)