### PR TITLE
Fix Buffer ReferenceError in browser runtime

### DIFF
--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -8,6 +8,7 @@
       "name": "rehasport-site",
       "version": "1.0.0",
       "dependencies": {
+        "buffer": "^6.0.3",
         "gray-matter": "^4.0.3",
         "mdast-util-to-string": "^4.0.0",
         "react": "^18.2.0",
@@ -1279,6 +1280,50 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
     "node_modules/chai": {
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.1.tgz",
@@ -1505,6 +1550,26 @@
       "engines": {
         "node": ">=6.0"
       }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/is-extendable": {
       "version": "0.1.1",

--- a/site/package.json
+++ b/site/package.json
@@ -11,6 +11,7 @@
     "test": "vitest"
   },
   "dependencies": {
+    "buffer": "^6.0.3",
     "gray-matter": "^4.0.3",
     "mdast-util-to-string": "^4.0.0",
     "react": "^18.2.0",

--- a/site/src/main.tsx
+++ b/site/src/main.tsx
@@ -1,9 +1,14 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
+import { Buffer } from "buffer";
 
 import App from "./App";
 import "./index.css";
+
+if (!globalThis.Buffer) {
+  (globalThis as typeof globalThis & { Buffer: typeof Buffer }).Buffer = Buffer;
+}
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>


### PR DESCRIPTION
## Summary
- add a browser polyfill for Buffer during app bootstrap to avoid runtime errors
- add the `buffer` dependency so Vite bundles the polyfill

## Testing
- npm run test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918d71f1d808333b6639af7306b828c)