### PR TITLE
fix: ensure buffer polyfill executes before app initialization

### DIFF
--- a/site/src/main.tsx
+++ b/site/src/main.tsx
@@ -1,14 +1,10 @@
+import "./polyfills";
 import React from "react";
 import ReactDOM from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
-import { Buffer } from "buffer";
 
 import App from "./App";
 import "./index.css";
-
-if (!globalThis.Buffer) {
-  (globalThis as typeof globalThis & { Buffer: typeof Buffer }).Buffer = Buffer;
-}
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>

--- a/site/src/polyfills.ts
+++ b/site/src/polyfills.ts
@@ -1,0 +1,5 @@
+import { Buffer } from "buffer";
+
+if (!globalThis.Buffer) {
+  (globalThis as typeof globalThis & { Buffer: typeof Buffer }).Buffer = Buffer;
+}


### PR DESCRIPTION
## Summary
- move the Buffer global setup into a dedicated polyfills module
- import the polyfill before rendering the app to avoid ReferenceError in the browser

## Testing
- npm run test -- --watch=false *(fails: Cannot find package 'gray-matter' imported from src/content/sessions.ts)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918d82272f4833389091ccf659a23e2)