### PR TITLE
Optimiere Stundenansicht für mobile Nutzung und füge Theme-Switcher I…

### DIFF
--- a/site/src/components/ui/ThemeSwitcher.tsx
+++ b/site/src/components/ui/ThemeSwitcher.tsx
@@ -1,38 +1,35 @@
-import { ChangeEvent, useId } from "react";
-
 import { ThemeMode, useTheme } from "../theme/ThemeProvider";
 
-const OPTIONS: Array<{ value: ThemeMode; label: string }> = [
-  { value: "light", label: "Hell" },
-  { value: "dark", label: "Dunkel" },
-  { value: "system", label: "System" }
+const OPTIONS: Array<{ value: ThemeMode; label: string; icon: string }> = [
+  { value: "light", label: "Hell", icon: "☀️" },
+  { value: "dark", label: "Dunkel", icon: "🌙" },
+  { value: "system", label: "System", icon: "💻" }
 ];
 
 function ThemeSwitcher(): JSX.Element {
   const { mode, setMode } = useTheme();
-  const id = useId();
 
-  const handleChange = (event: ChangeEvent<HTMLSelectElement>) => {
-    setMode(event.target.value as ThemeMode);
-  };
+  const currentOption = OPTIONS.find((opt) => opt.value === mode) ?? OPTIONS[2];
+
+  function cycleTheme(): void {
+    const currentIndex = OPTIONS.findIndex((opt) => opt.value === mode);
+    const nextIndex = (currentIndex + 1) % OPTIONS.length;
+    setMode(OPTIONS[nextIndex].value);
+  }
 
   return (
-    <label className="theme-switch" htmlFor={id}>
-      <span className="visually-hidden">Darstellungsmodus wählen</span>
-      <select
-        id={id}
-        value={mode}
-        onChange={handleChange}
-        className="theme-switch__select"
-        aria-label="Darstellungsmodus"
-      >
-        {OPTIONS.map((option) => (
-          <option key={option.value} value={option.value}>
-            {option.label}
-          </option>
-        ))}
-      </select>
-    </label>
+    <button
+      type="button"
+      className="theme-switch"
+      onClick={cycleTheme}
+      aria-label={`Theme: ${currentOption.label}. Klicken zum Wechseln`}
+      title={`Theme: ${currentOption.label}`}
+    >
+      <span className="theme-switch__icon" aria-hidden="true">
+        {currentOption.icon}
+      </span>
+      <span className="visually-hidden">{currentOption.label}</span>
+    </button>
   );
 }
 

--- a/site/src/index.css
+++ b/site/src/index.css
@@ -209,28 +209,40 @@ a:focus-visible {
 }
 
 .theme-switch {
-  display: flex;
+  display: inline-flex;
   align-items: center;
-}
-
-.theme-switch__select {
-  border-radius: 999px;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 50%;
   border: 1px solid var(--color-border);
   background: var(--color-surface);
-  color: var(--color-text);
-  padding: 0.35rem 1.25rem 0.35rem 0.75rem;
-  font-weight: 600;
   cursor: pointer;
-  transition: border-color 0.15s ease, background 0.15s ease;
+  transition: all 0.2s ease;
+  font-size: 1.25rem;
+  padding: 0;
 }
 
-.theme-switch__select:focus-visible {
+.theme-switch:hover {
+  background: var(--color-primary-soft);
+  border-color: var(--color-primary);
+  transform: scale(1.05);
+}
+
+.theme-switch:focus-visible {
   outline: 2px solid var(--color-secondary);
   outline-offset: 2px;
 }
 
-.theme-switch__select:hover {
-  border-color: var(--color-secondary);
+.theme-switch:active {
+  transform: scale(0.95);
+}
+
+.theme-switch__icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 1;
 }
 
 .site-footer {
@@ -797,6 +809,219 @@ a:focus-visible {
   color: var(--color-text-muted);
 }
 
+.session-phases {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-lg);
+}
+
+.session-phase {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+}
+
+.session-phase__header {
+  background: var(--color-surface);
+  padding: var(--spacing-sm) var(--spacing-md);
+  border-radius: 16px;
+  box-shadow: var(--shadow-sm);
+  border-left: 4px solid var(--color-border);
+  transition: border-color 0.2s ease;
+}
+
+.session-phase__title {
+  font-size: 1.3rem;
+  margin: 0 0 0.5rem;
+  color: var(--color-primary-strong);
+}
+
+.session-phase__description {
+  margin: 0;
+  color: var(--color-text-muted);
+  font-size: 0.95rem;
+}
+
+/* Phase color coding */
+.phase-warmup .session-phase__header {
+  border-left-color: #3b82f6;
+}
+
+.phase-warmup .session-phase__title {
+  color: #3b82f6;
+}
+
+.phase-main .session-phase__header {
+  border-left-color: #10b981;
+}
+
+.phase-main .session-phase__title {
+  color: #10b981;
+}
+
+.phase-focus .session-phase__header {
+  border-left-color: #f59e0b;
+}
+
+.phase-focus .session-phase__title {
+  color: #f59e0b;
+}
+
+.phase-cooldown .session-phase__header {
+  border-left-color: #8b5cf6;
+}
+
+.phase-cooldown .session-phase__title {
+  color: #8b5cf6;
+}
+
+.exercise--compact {
+  padding: 0;
+}
+
+.exercise__toggle {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  width: 100%;
+  background: transparent;
+  border: none;
+  padding: var(--spacing-sm);
+  text-align: left;
+  cursor: pointer;
+  font: inherit;
+  border-radius: 16px;
+  transition: background 0.15s ease;
+}
+
+.exercise__toggle:hover {
+  background: var(--color-primary-soft);
+}
+
+.exercise__toggle:focus-visible {
+  outline: 3px solid var(--color-secondary);
+  outline-offset: 3px;
+  background: var(--color-primary-soft);
+}
+
+.exercise__main {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  min-width: 0;
+}
+
+.exercise__title-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.exercise__title {
+  font-size: 1.1rem;
+  line-height: 1.35;
+}
+
+.exercise__alternatives {
+  display: inline-flex;
+  gap: 0.25rem;
+  align-items: center;
+}
+
+.alternative-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.5rem;
+  height: 1.5rem;
+  border-radius: 50%;
+  font-size: 0.7rem;
+  font-weight: 700;
+  color: #ffffff;
+  flex-shrink: 0;
+}
+
+.alternative-icon--knee {
+  background: #3b82f6;
+}
+
+.alternative-icon--shoulder {
+  background: #f59e0b;
+}
+
+.exercise__primary {
+  color: var(--color-text-muted);
+  font-size: 0.9rem;
+  font-weight: 400;
+}
+
+.exercise__icon {
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: var(--color-secondary);
+  min-width: 2rem;
+  text-align: center;
+}
+
+.exercise__expanded {
+  padding: 0 var(--spacing-sm) var(--spacing-sm);
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+}
+
+.exercise__expanded .exercise__details {
+  background: var(--color-background);
+  padding: var(--spacing-sm);
+  border-radius: 12px;
+}
+
+.exercise__expanded .exercise__link {
+  align-self: flex-start;
+}
+
+.detail--alternative {
+  border-left: 3px solid var(--color-secondary-soft);
+  padding-left: 0.75rem;
+}
+
+.detail--alternative dt {
+  color: var(--color-secondary);
+}
+
+/* Smooth transitions for expanded content */
+.exercise__expanded {
+  animation: slideDown 0.2s ease-out;
+}
+
+@keyframes slideDown {
+  from {
+    opacity: 0;
+    transform: translateY(-8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* Focus improvements for keyboard navigation */
+.exercise__toggle:focus-visible::before {
+  content: "";
+  position: absolute;
+  inset: -4px;
+  border-radius: 20px;
+  border: 3px solid var(--color-secondary);
+  pointer-events: none;
+}
+
+.exercise--compact {
+  position: relative;
+  scroll-margin-top: 120px;
+}
+
 @media (max-width: 640px) {
   main {
     padding: var(--spacing-md) 0 var(--spacing-lg);
@@ -860,5 +1085,36 @@ a:focus-visible {
 
   .exercise__details {
     grid-template-columns: 1fr;
+  }
+
+  .session-phase__title {
+    font-size: 1.15rem;
+  }
+
+  .exercise__toggle {
+    align-items: flex-start;
+  }
+
+  .exercise__main {
+    padding-right: 0.5rem;
+  }
+
+  .exercise__title {
+    font-size: 1rem;
+  }
+
+  .exercise__primary {
+    font-size: 0.85rem;
+  }
+
+  .alternative-icon {
+    width: 1.35rem;
+    height: 1.35rem;
+    font-size: 0.65rem;
+  }
+
+  .exercise__toggle:focus-visible {
+    outline-width: 2px;
+    outline-offset: 2px;
   }
 }


### PR DESCRIPTION
…cons hinzu

- Stundenansicht komplett überarbeitet für mobile Nutzung:
  - Button-Navigation entfernt zugunsten scrollbarer Liste
  - Übungen zeigen nur Titel + Wiederholungen, Details in Dropdown
  - Phasen (Aufwärmen, Hauptteil, Schwerpunkt, Ausklang) farbcodiert
  - Automatisches Scrollen zur ausgeklappten Übung
  - Haptic Feedback beim Aufklappen (mobile)

- Knie/Schulter-Alternativen als kompakte Icons (K/S) statt Text
- Verbesserte Fokus-Indikatoren für Tastaturnutzung
- Smooth Animations für bessere UX

- Theme-Switcher: Dropdown durch Icon-Button ersetzt
  - Durchklicken: Hell (☀️) → Dunkel (🌙) → System (💻)
  - Kompakteres Design mit Hover-Effekten

🤖 Generated with [Claude Code](https://claude.com/claude-code)