### PR TITLE
Füge separate Gymnastikstab- und Redondo-Ball-Stunden hinzu

### DIFF
--- a/stunden/ruecken/gymnastikstab.md
+++ b/stunden/ruecken/gymnastikstab.md
@@ -1,0 +1,148 @@
+---
+beschreibung: Rückenfreundliche Einheit mit Gymnastikstab für Mobilität, Haltung und Koordination.
+dauer: 45 Minuten
+fokus: Rücken, Mobilität, Haltung, Schulterbeweglichkeit
+konzept: ../../Konzepte/rückengesundheit.md
+---
+
+# Gymnastikstab
+
+## Übersicht
+- **Konzept:** [Rückengesundheit](../../Konzepte/rückengesundheit.md)
+- **Gesamtdauer:** 45 Minuten
+- **Schwierigkeitsgrad:** Leicht bis Mittel
+- **Zielgruppe:** Teilnehmer mit Rückenbeschwerden, eingeschränkter Schulterbeweglichkeit, Büroalltag
+- **Leitfaden:** [Stunden planen](../../Anleitung/stunden_planen.md)
+- **Benötigte Materialien:** Gymnastikstab (100-120 cm) pro Teilnehmer
+
+## Lernziele
+- Brustwirbelsäule mobilisieren und Rotationsfähigkeit verbessern
+- Schulterbeweglichkeit erweitern und Fehlhaltungen korrigieren
+- Seitliche Rumpfkette stärken für bessere Alltagsstabilität
+- Körperwahrnehmung und Koordination mit dem Stab schulen
+
+## Phasenplan
+
+### Phase 1: Aufwärmen (10 Minuten)
+**Ziel:** Wirbelsäule mobilisieren, Schultern aktivieren, Stab kennenlernen.
+
+1. [Stab-Rotation im Stand](../../Übungen/stab_rotation_im_stand.md)
+   - **Durchführung:** 2 x 12 Rotationen pro Seite, Stab auf den Schultern.
+   - **Coaching:** Becken bleibt stabil, Bewegung nur aus der Brustwirbelsäule.
+   - **Knie-Alternative 🦵:** Im Sitzen auf Stuhl ausführen.
+   - **Schulter-Alternative 💪:** Stab vor der Brust halten statt auf Schultern.
+
+2. [Schulterkreisen](../../Übungen/schulterkreisen.md)
+   - **Durchführung:** 2 x 10 Kreise vorwärts, 2 x 10 Kreise rückwärts.
+   - **Coaching:** Schultern tief halten, große Kreise aus dem Schultergelenk.
+   - **Knie-Alternative 🦵:** Im Sitzen ausführen.
+   - **Schulter-Alternative 💪:** Kleiner Bewegungsradius, Arme angewinkelt.
+
+3. [Rumpfrotation im Stand](../../Übungen/rumpfrotation_im_stand.md)
+   - **Durchführung:** 2 x 12 Rotationen pro Seite, Stab waagerecht vor der Brust.
+   - **Coaching:** Becken zeigt nach vorne, Bewegung aus Brustwirbelsäule.
+   - **Knie-Alternative 🦵:** Im Sitzen auf Stuhl ausführen.
+   - **Schulter-Alternative 💪:** Stab locker halten, kleinerer Bewegungsumfang.
+
+4. [Marschieren auf der Stelle](../../Übungen/marschieren_auf_der_stelle.md)
+   - **Durchführung:** 2 Minuten lockeres Marschieren, Stab senkrecht als Gehstütze.
+   - **Coaching:** Aufrechte Haltung, Knie aktiv heben.
+   - **Knie-Alternative 🦵:** Kleinere Schritte, Knie weniger hoch.
+   - **Schulter-Alternative 💪:** Stab nur leicht halten, kein Druck.
+
+### Phase 2: Hauptteil (15 Minuten)
+**Ziel:** Schultermobilität verbessern, funktionelle Kräftigung mit dem Stab.
+
+1. [Stab-Schultermobilisation](../../Übungen/stab_schultermobilisation.md)
+   - **Durchführung:** 3 Sätze à 10-12 Wiederholungen, Stab über Kopf führen.
+   - **Coaching:** Arme gestreckt, Schultern tief, kein Hohlkreuz.
+   - **Knie-Alternative 🦵:** Im Sitzen auf Stuhl ausführen.
+   - **Schulter-Alternative 💪:** Stab nur bis Schulterhöhe, breiterer Griff.
+
+2. [Vogel-Hund](../../Übungen/vogel_hund.md)
+   - **Durchführung:** 3 Sätze à 8 Wiederholungen pro Seite.
+   - **Coaching:** Becken parallel, Blick zum Boden, diagonal strecken.
+   - **Knie-Alternative 🦵:** Kissen unter Knie oder im Stand an Wand.
+   - **Schulter-Alternative 💪:** Armbewegung verkürzen oder weglassen.
+
+3. [Beckenlift](../../Übungen/beckenlift.md)
+   - **Durchführung:** 2 Sätze à 12 Wiederholungen, oben 3 Sekunden halten.
+   - **Coaching:** Wirbel für Wirbel abrollen, Gesäß aktivieren.
+   - **Knie-Alternative 🦵:** Füße weiter vom Gesäß, kleinere Bewegung.
+   - **Schulter-Alternative 💪:** Arme seitlich ablegen.
+
+4. [Kniebeuge (Wandstütze)](../../Übungen/kniebeuge_wandstütze.md)
+   - **Durchführung:** 3 Sätze à 10 Wiederholungen, Stab als Balance-Hilfe.
+   - **Coaching:** Rücken an Wand, Knie bleiben hinter Zehen, Core aktiv.
+   - **Knie-Alternative 🦵:** Bewegungsumfang reduzieren, Stuhl als zusätzliche Sicherung.
+   - **Schulter-Alternative 💪:** Stab vor dem Körper statt über Kopf.
+
+### Phase 3: Schwerpunkt (15 Minuten)
+**Ziel:** Seitliche Rumpfkraft aufbauen, Haltung und Koordination trainieren.
+
+1. [Stab-Seitneigung](../../Übungen/stab_seitneigung.md)
+   - **Durchführung:** 3 Sätze à 10 Wiederholungen pro Seite, 2 Sek halten.
+   - **Coaching:** Stab bleibt parallel zum Boden, reine Seitneigung ohne Rotation.
+   - **Knie-Alternative 🦵:** Im Sitzen auf Stuhl ausführen.
+   - **Schulter-Alternative 💪:** Stab vor der Brust oder Hände an der Hüfte.
+
+2. [Planke an der Wand](../../Übungen/planke_an_der_wand.md)
+   - **Durchführung:** 3 x 30-40 Sekunden halten.
+   - **Coaching:** Körper in Linie, Bauchnabel zur Wirbelsäule.
+   - **Knie-Alternative 🦵:** Füße näher an Wand, weniger Druck.
+   - **Schulter-Alternative 💪:** Unterarmvariante oder Hände höher.
+
+3. [Seitstütz (Knie modifiziert)](../../Übungen/seitstütz_knie_modifiziert.md)
+   - **Durchführung:** 2 x 20-30 Sekunden pro Seite.
+   - **Coaching:** Hüfte anheben, Körper gerade, nicht durchhängen.
+   - **Knie-Alternative 🦵:** Unteres Bein stärker beugen.
+   - **Schulter-Alternative 💪:** Unterarm direkt unter Schulter, kürzere Haltezeit.
+
+4. [Rumpfrotation mit Gewicht](../../Übungen/rumpfrotation_mit_gewicht.md)
+   - **Durchführung:** 2 Sätze à 12 Rotationen pro Seite mit dem Stab.
+   - **Coaching:** Länge in der Wirbelsäule halten, Bewegung aus Brustwirbelsäule.
+   - **Knie-Alternative 🦵:** Im Sitzen auf Stuhl ausführen.
+   - **Schulter-Alternative 💪:** Stab locker halten, kleinere Bewegung.
+
+### Phase 4: Ausklang (10 Minuten)
+**Ziel:** Muskulatur dehnen, Entspannen, Atmung beruhigen.
+
+1. [Stab-Brustdehnung](../../Übungen/stab_brustdehnung.md)
+   - **Durchführung:** 3 x 20-30 Sekunden Dehnung, Stab hinter dem Rücken.
+   - **Coaching:** Nur bis zur angenehmen Dehnung, ruhig atmen.
+   - **Knie-Alternative 🦵:** Im Sitzen ausführen.
+   - **Schulter-Alternative 💪:** Breiterer Griff, kleinerer Bewegungsumfang.
+
+2. [Katze-Kuh](../../Übungen/katze_kuh.md)
+   - **Durchführung:** 1-2 Minuten im Vierfüßler, langsamer Wechsel.
+   - **Coaching:** Bewegung fließend, Atmung führt die Bewegung.
+   - **Knie-Alternative 🦵:** Sitzende Variante auf Stuhl.
+   - **Schulter-Alternative 💪:** Hände weiter vorne oder auf Unterarme.
+
+3. [Seitliche Rumpfdehnung im Sitzen](../../Übungen/seitliche_rumpfdehnung_im_sitzen.md)
+   - **Durchführung:** 2 x 20 Sekunden pro Seite, Stab über Kopf.
+   - **Coaching:** Länge in der Wirbelsäule, sanfte Dehnung.
+   - **Knie-Alternative 🦵:** Füße flach am Boden, kein zusätzlicher Druck.
+   - **Schulter-Alternative 💪:** Stab nur bis Schulterhöhe oder weglassen.
+
+4. [Atemübung mit Armen](../../Übungen/atemuebung_mit_armen.md)
+   - **Durchführung:** 8-10 tiefe Atemzüge mit Armbewegung.
+   - **Coaching:** Einatmen – Arme heben, Ausatmen – Arme senken.
+   - **Knie-Alternative 🦵:** Im Sitzen ausführen.
+   - **Schulter-Alternative 💪:** Arme nur bis Schulterhöhe.
+
+## Abschluss
+- **Reflexionsfrage:** „An welcher Stelle hat der Stab Ihnen geholfen, die Bewegung besser zu spüren?"
+- **Hausaufgabe:** Täglich 2 Minuten Stab-Rotation oder Stab-Seitneigung.
+- **Materialhinweis:** Ein Besenstiel kann als kostengünstiger Stab-Ersatz dienen.
+
+## Wichtige Hinweise für den Übungsleiter
+- Vor der Stunde Stäbe auf Zustand prüfen (keine Splitter, Risse)
+- Genügend Platz zwischen Teilnehmern für Stab-Übungen einplanen (Armreichweite + Stablänge)
+- Bei Gleichgewichtsproblemen: Stühle als Sicherung bereitstellen
+- Stablänge: Stab sollte etwa vom Boden bis zur Brust reichen
+
+## Anpassungen je nach Gruppe
+- **Anfänger**: Kürzere Haltezeiten, mehr Pausen, Stühle zur Sicherung
+- **Fortgeschrittene**: Längere Haltezeiten, mehr Wiederholungen, komplexere Kombinationen
+- **Senioren**: Leichtere Stäbe, kürzere Sets, mehr Hilfestellung beim Positionswechsel

--- a/stunden/ruecken/redondo_ball.md
+++ b/stunden/ruecken/redondo_ball.md
@@ -1,0 +1,148 @@
+---
+beschreibung: Rückenfreundliche Einheit mit Redondo-Ball für Mobilität, Stabilität und Tiefenmuskulatur.
+dauer: 45 Minuten
+fokus: Rücken, Mobilität, Rumpfstabilität, Propriozeption
+konzept: ../../Konzepte/rückengesundheit.md
+---
+
+# Redondo-Ball
+
+## Übersicht
+- **Konzept:** [Rückengesundheit](../../Konzepte/rückengesundheit.md)
+- **Gesamtdauer:** 45 Minuten
+- **Schwierigkeitsgrad:** Leicht bis Mittel
+- **Zielgruppe:** Teilnehmer mit Rückenbeschwerden, eingeschränkter Beweglichkeit, Büroalltag
+- **Leitfaden:** [Stunden planen](../../Anleitung/stunden_planen.md)
+- **Benötigte Materialien:** Redondo-Ball (22-26 cm) pro Teilnehmer
+
+## Lernziele
+- Wirbelsäule sanft mobilisieren und Verspannungen lösen
+- Tiefe Rumpfmuskulatur aktivieren und kräftigen
+- Körperwahrnehmung durch propriozeptives Training schulen
+- Beckenkontrolle und -beweglichkeit verbessern
+
+## Phasenplan
+
+### Phase 1: Aufwärmen (10 Minuten)
+**Ziel:** Wirbelsäule mobilisieren, Muskulatur aktivieren, Ball kennenlernen.
+
+1. [Redondo-Ball Rückenmobilisation](../../Übungen/redondo_rueckenmobilisation.md)
+   - **Durchführung:** Ball unter LWS, 10-12 Kippbewegungen, dann unter BWS wiederholen.
+   - **Coaching:** Langsam und entspannt, Ball passt sich der Wirbelsäule an.
+   - **Knie-Alternative 🦵:** Beine auf Kissen lagern, weniger Beugung.
+   - **Schulter-Alternative 💪:** Arme entspannt neben dem Körper.
+
+2. [Schulterkreisen](../../Übungen/schulterkreisen.md)
+   - **Durchführung:** 2 x 10 Kreise vorwärts, 2 x 10 Kreise rückwärts.
+   - **Coaching:** Schultern tief halten, große Kreise aus dem Schultergelenk.
+   - **Knie-Alternative 🦵:** Im Sitzen ausführen.
+   - **Schulter-Alternative 💪:** Kleiner Bewegungsradius, Arme angewinkelt.
+
+3. [Knie zur Brust](../../Übungen/knie_zur_brust.md)
+   - **Durchführung:** In Rückenlage 2 Sätze à 10 Wiederholungen pro Seite.
+   - **Coaching:** Lendenwirbelsäule auf der Matte, Atmung fließen lassen.
+   - **Knie-Alternative 🦵:** Ein Bein aufgestellt lassen, Knie nur bis Wohlfühlposition.
+   - **Schulter-Alternative 💪:** Arme entspannt auf Unterlage, kein Zug an den Schultern.
+
+4. [Marschieren auf der Stelle](../../Übungen/marschieren_auf_der_stelle.md)
+   - **Durchführung:** 2 Minuten lockeres Marschieren, Arme mitschwingen.
+   - **Coaching:** Aufrechte Haltung, Knie aktiv heben.
+   - **Knie-Alternative 🦵:** Kleinere Schritte, Knie weniger hoch.
+   - **Schulter-Alternative 💪:** Arme an der Hüfte statt Schwungbewegung.
+
+### Phase 2: Hauptteil (15 Minuten)
+**Ziel:** Beckenkontrolle schulen, funktionelle Kräftigung mit dem Ball.
+
+1. [Redondo-Ball Beckenkippung](../../Übungen/redondo_beckenkippung.md)
+   - **Durchführung:** 2 Sätze à 15-20 Kippbewegungen im Sitzen auf dem Ball.
+   - **Coaching:** Bewegung aus dem Becken, nicht aus den Beinen. Neutrale Position finden.
+   - **Knie-Alternative 🦵:** Füße weiter vom Ball, größerer Kniewinkel.
+   - **Schulter-Alternative 💪:** Keine Anpassung nötig.
+
+2. [Vogel-Hund](../../Übungen/vogel_hund.md)
+   - **Durchführung:** 3 Sätze à 8 Wiederholungen pro Seite.
+   - **Coaching:** Becken parallel, Blick zum Boden, diagonal strecken.
+   - **Knie-Alternative 🦵:** Kissen unter Knie oder im Stand an Wand.
+   - **Schulter-Alternative 💪:** Armbewegung verkürzen oder weglassen.
+
+3. [Beckenlift](../../Übungen/beckenlift.md)
+   - **Durchführung:** 2 Sätze à 12 Wiederholungen, Ball zwischen den Knien.
+   - **Coaching:** Wirbel für Wirbel abrollen, Gesäß aktivieren, Ball leicht zusammendrücken.
+   - **Knie-Alternative 🦵:** Füße weiter vom Gesäß, kleinere Bewegung.
+   - **Schulter-Alternative 💪:** Arme seitlich ablegen.
+
+4. [Oberkörper heben (Bauch)](../../Übungen/oberkörper_heben_bauch.md)
+   - **Durchführung:** 2 Sätze à 12 Wiederholungen, Ball zwischen den Knien.
+   - **Coaching:** Kinn zur Brust, Lendenwirbelsäule bleibt auf der Matte.
+   - **Knie-Alternative 🦵:** Beine aufgestellt lassen, Bewegungsumfang verkleinern.
+   - **Schulter-Alternative 💪:** Hände über Brust verschränken statt hinter Kopf.
+
+### Phase 3: Schwerpunkt (15 Minuten)
+**Ziel:** Tiefenmuskulatur intensiv trainieren, Propriozeption fördern.
+
+1. [Redondo-Ball Rumpfstabilisation](../../Übungen/redondo_rumpfstabilisation.md)
+   - **Durchführung:** 3 Sätze à 10-12 Wiederholungen, Ball zwischen den Knien.
+   - **Coaching:** Lendenwirbelsäule bleibt am Boden, Beine nur so weit senken wie Kontakt gehalten wird.
+   - **Knie-Alternative 🦵:** Ball zwischen Unterschenkel, Beine aufgestellt lassen.
+   - **Schulter-Alternative 💪:** Arme auf Kissen lagern.
+
+2. [Planke an der Wand](../../Übungen/planke_an_der_wand.md)
+   - **Durchführung:** 3 x 30-40 Sekunden halten.
+   - **Coaching:** Körper in Linie, Bauchnabel zur Wirbelsäule.
+   - **Knie-Alternative 🦵:** Füße näher an Wand, weniger Druck.
+   - **Schulter-Alternative 💪:** Unterarmvariante oder Hände höher.
+
+3. [Seitstütz (Knie modifiziert)](../../Übungen/seitstütz_knie_modifiziert.md)
+   - **Durchführung:** 2 x 20-30 Sekunden pro Seite.
+   - **Coaching:** Hüfte anheben, Körper gerade, nicht durchhängen.
+   - **Knie-Alternative 🦵:** Unteres Bein stärker beugen.
+   - **Schulter-Alternative 💪:** Unterarm direkt unter Schulter, kürzere Haltezeit.
+
+4. [Schulterbrücke einbeinig](../../Übungen/schulterbrücke_einbeinig.md)
+   - **Durchführung:** 2 Sätze à 8 Wiederholungen pro Seite, Ball unter Standfuß.
+   - **Coaching:** Hüften parallel, keine Rotation, Ball für Instabilität.
+   - **Knie-Alternative 🦵:** Beidbeinige Brücke mit Ball zwischen Knien.
+   - **Schulter-Alternative 💪:** Arme am Boden belassen, Schultern entspannen.
+
+### Phase 4: Ausklang (10 Minuten)
+**Ziel:** Muskulatur dehnen, Entspannen, Atmung beruhigen.
+
+1. [Redondo-Ball Entspannung](../../Übungen/redondo_entspannung.md)
+   - **Durchführung:** 45-60 Sekunden Ball unter Kreuzbein, dann unter BWS.
+   - **Coaching:** Gewicht sinken lassen, tiefe Bauchatmung, entspannen.
+   - **Knie-Alternative 🦵:** Beine lang ausstrecken oder auf Stuhl ablegen.
+   - **Schulter-Alternative 💪:** Arme neben dem Körper statt über Kopf.
+
+2. [Katze-Kuh](../../Übungen/katze_kuh.md)
+   - **Durchführung:** 1-2 Minuten im Vierfüßler, langsamer Wechsel.
+   - **Coaching:** Bewegung fließend, Atmung führt die Bewegung.
+   - **Knie-Alternative 🦵:** Sitzende Variante auf Stuhl.
+   - **Schulter-Alternative 💪:** Hände weiter vorne oder auf Unterarme.
+
+3. [Dehnung Hüftbeuger](../../Übungen/dehnung_hüftbeuger.md)
+   - **Durchführung:** 2 x 30 Sekunden pro Seite im Halbkniestand.
+   - **Coaching:** Oberkörper aufrecht, Becken nach vorne schieben.
+   - **Knie-Alternative 🦵:** Im Stand mit kleinem Ausfallschritt.
+   - **Schulter-Alternative 💪:** Arm nur bis Schulterhöhe heben.
+
+4. [Atemübung mit Armen](../../Übungen/atemuebung_mit_armen.md)
+   - **Durchführung:** 8-10 tiefe Atemzüge mit Armbewegung.
+   - **Coaching:** Einatmen – Arme heben, Ausatmen – Arme senken.
+   - **Knie-Alternative 🦵:** Im Sitzen ausführen.
+   - **Schulter-Alternative 💪:** Arme nur bis Schulterhöhe.
+
+## Abschluss
+- **Reflexionsfrage:** „Wo haben Sie den Ball am intensivsten gespürt – unter dem Rücken oder zwischen den Knien?"
+- **Hausaufgabe:** Täglich 2 Minuten Redondo-Ball Rückenmobilisation oder Beckenkippung.
+- **Materialhinweis:** Redondo-Bälle gibt es im Sportfachhandel (ca. 10-15€). Alternativ kann ein weicher Softball verwendet werden.
+
+## Wichtige Hinweise für den Übungsleiter
+- Vor der Stunde Ball-Luftdruck prüfen (eher weich für Anfänger)
+- Genügend Platz für Bodenübungen einplanen
+- Bei Gleichgewichtsproblemen: Stühle als Sicherung bereitstellen
+- Ball-Größe: 22-26 cm Durchmesser sind optimal für die meisten Übungen
+
+## Anpassungen je nach Gruppe
+- **Anfänger**: Ball weicher aufpumpen, kürzere Haltezeiten, mehr Pausen
+- **Fortgeschrittene**: Ball fester aufpumpen, längere Haltezeiten, Augen schließen bei Balance-Übungen
+- **Senioren**: Ball sehr weich, kürzere Sets, mehr Hilfestellung beim Positionswechsel

--- a/Übungen/redondo_beckenkippung.md
+++ b/Übungen/redondo_beckenkippung.md
@@ -1,0 +1,93 @@
+# Redondo-Ball Beckenkippung
+
+## Kategorie
+
+- **Bereich**: Hauptteil
+- **Schwerpunkt**: Koordination
+- **Dauer**: 4 Minuten
+- **Schwierigkeitsgrad**: Mittel
+
+## Beschreibung
+
+Gezielte Aktivierung der tiefen Bauch- und Rückenmuskulatur durch kontrollierte Beckenbewegungen auf dem Redondo-Ball. Im Sitzen auf dem Ball werden Becken-Vor- und Rückkippung geübt. Trainiert die Körperwahrnehmung und die Kontrolle der Lendenwirbelsäule.
+
+## Ausführung
+
+1. Aufrechter Sitz auf dem Redondo-Ball, Füße hüftbreit am Boden.
+2. Hände auf die Hüftknochen legen zur Kontrolle der Bewegung.
+3. Becken langsam nach vorne kippen – Hohlkreuz entsteht.
+4. Becken langsam nach hinten kippen – Lendenwirbelsäule rundet sich.
+5. Zwischen beiden Positionen wechseln, neutrale Position finden. 15-20 Wiederholungen.
+
+## Zielmuskulatur
+
+- **Primär**: Transversus abdominis, Multifidi, Beckenboden
+- **Sekundär**: Gerader Bauchmuskel, Hüftbeuger, Gesäßmuskulatur
+
+## Hilfsmittel
+
+- Redondo-Ball (ca. 22-26 cm Durchmesser)
+- Optional: Stuhl oder Wand zur Stabilisierung
+
+## Geeignet für
+
+- Teilnehmer mit Lendenwirbelsäulen-Problemen
+- Personen mit schwacher Tiefenmuskulatur
+- **Besonders empfohlen bei**: Beckenbodenschwäche, Haltungsproblemen, nach Schwangerschaft
+
+## Nicht geeignet für / Kontraindikationen
+
+- ⚠️ **Nicht bei akuten Verletzungen**: Akute Bandscheibenvorfälle der LWS, akute ISG-Blockierung
+- ⚠️ **Vorsicht bei**: Starke Gleichgewichtsstörungen, Hüftprothesen (Bewegungsumfang beachten)
+- ⚠️ **Kontraindiziert bei**: Schwere Osteoporose mit Frakturgefahr, akute Entzündungen im Beckenbereich
+
+## Alternativen
+
+### Bei Knieproblemen 🦵
+
+- **Alternative Übung**: Füße weiter vom Ball entfernt aufstellen
+- **Anpassung**: Kniewinkel größer als 90°, ggf. Stuhl zur Abstützung
+- **Hinweis**: Bei starken Knieproblemen: Übung in Rückenlage mit Ball unter dem Kreuzbein
+
+### Bei Schulterproblemen 💪
+
+- **Alternative Übung**: Keine Anpassung nötig – Schultern nicht belastet
+- **Anpassung**: Hände auf Oberschenkel statt Hüfte
+- **Hinweis**: Diese Übung ist schulterfreundlich
+
+### Weitere Anpassungen
+
+- **Vereinfachung (Anfänger)**: Ball neben Wand, eine Hand zur Stabilisierung, kleinere Bewegungen
+- **Steigerung (Fortgeschrittene)**: Augen schließen, Arme vor der Brust verschränken
+- **Für Senioren**: Stuhl oder Wand zur Sicherung, Ball weicher aufpumpen
+
+## Wichtige Hinweise
+
+- **Atmung**: Ausatmen bei Rückkippung (Bauchnabel zur Wirbelsäule), Einatmen bei Vorkippung
+- **Häufige Fehler**: Bewegung aus den Beinen statt aus dem Becken, zu große/schnelle Bewegungen
+- **Sicherheit**: Ball auf rutschfester Unterlage, Stuhl in Reichweite
+- **Tempo**: Langsam und kontrolliert, 3 Sekunden pro Richtung
+
+## Variationen
+
+- **Variation 1**: Seitliches Kippen – Gewichtsverlagerung rechts/links
+- **Variation 2**: Kreisende Beckenbewegungen auf dem Ball
+
+## Verwandte Übungen
+
+- [Beckenlift](./beckenlift.md)
+- [Katze-Kuh](./katze_kuh.md)
+- [Vogel-Hund](./vogel_hund.md)
+
+## Wissenswertes
+
+Die Beckenkippung ist eine fundamentale Bewegung für die Wirbelsäulengesundheit. Im Alltag verlieren viele Menschen das Gefühl für diese Bewegung. Der Redondo-Ball macht die Kippung spürbar und gibt sofortiges Feedback über die Bewegungsqualität.
+
+## Wird verwendet in
+
+- [Stunde: Stab & Redondo-Ball](../stunden/ruecken/stab-und-redondo.md)
+
+---
+**Tags**: #hauptteil #koordination #becken #core #redondo
+**Erstellt**: 02.12.2025
+**Letzte Änderung**: 02.12.2025

--- a/Übungen/redondo_entspannung.md
+++ b/Übungen/redondo_entspannung.md
@@ -1,0 +1,92 @@
+# Redondo-Ball Entspannung
+
+## Kategorie
+
+- **Bereich**: Ausklang
+- **Schwerpunkt**: Beweglichkeit
+- **Dauer**: 3 Minuten
+- **Schwierigkeitsgrad**: Leicht
+
+## Beschreibung
+
+Entspannende Abschlussübung mit dem Redondo-Ball zur Lockerung der Rückenmuskulatur. Der Ball wird unter verschiedenen Körperregionen platziert und durch sanftes Körpergewicht und kleine Bewegungen werden Verspannungen gelöst. Fördert die Regeneration und das Wohlbefinden.
+
+## Ausführung
+
+1. Rückenlage, Beine aufgestellt, Körper entspannt.
+2. Redondo-Ball unter das Kreuzbein legen, Becken leicht anheben.
+3. Gewicht auf den Ball sinken lassen, sanft hin und her wiegen.
+4. Ball unter die Brustwirbelsäule schieben, Arme seitlich oder über dem Kopf ablegen.
+5. 30-60 Sekunden pro Position, ruhig atmen und entspannen.
+
+## Zielmuskulatur
+
+- **Primär**: Paravertebrale Muskulatur, autochthone Rückenmuskulatur
+- **Sekundär**: Gesäßmuskulatur, Schulterblattmuskulatur (bei BWS-Position)
+
+## Hilfsmittel
+
+- Redondo-Ball (ca. 22-26 cm Durchmesser, eher weich aufgepumpt)
+
+## Geeignet für
+
+- Alle Teilnehmer als Abschluss einer Trainingseinheit
+- Personen mit Rückenverspannungen
+- **Besonders empfohlen bei**: Muskelverhärtungen, Stress-bedingten Verspannungen, nach intensivem Training
+
+## Nicht geeignet für / Kontraindikationen
+
+- ⚠️ **Nicht bei akuten Verletzungen**: Akute Bandscheibenvorfälle, frische Wirbelkörperfrakturen
+- ⚠️ **Vorsicht bei**: Starke Osteoporose, Herzschrittmacher (Ball nicht über Brustbereich)
+- ⚠️ **Kontraindiziert bei**: Offene Wunden im Rückenbereich, akute Entzündungen der Wirbelsäule
+
+## Alternativen
+
+### Bei Knieproblemen 🦵
+
+- **Alternative Übung**: Beine auf einem Stuhl ablegen oder lang ausstrecken
+- **Anpassung**: Knie nicht stark beugen, ggf. Kissen unter die Kniekehlen
+- **Hinweis**: Die Übung ist grundsätzlich knieschonend
+
+### Bei Schulterproblemen 💪
+
+- **Alternative Übung**: Arme neben dem Körper ablegen statt über dem Kopf
+- **Anpassung**: Bei BWS-Position keine Armstreckung über Kopf
+- **Hinweis**: Schultern entspannt auf dem Boden lassen
+
+### Weitere Anpassungen
+
+- **Vereinfachung (Anfänger)**: Ball weicher aufpumpen, nur Kreuzbein-Position
+- **Steigerung (Fortgeschrittene)**: Ball fester, längere Haltezeit, Arme über Kopf
+- **Für Senioren**: Ball sehr weich, Hilfe beim Hinlegen/Aufstehen, Kopfkissen
+
+## Wichtige Hinweise
+
+- **Atmung**: Tiefe Bauchatmung, mit jeder Ausatmung tiefer in die Entspannung sinken
+- **Häufige Fehler**: Zu viel Spannung halten, Atem anhalten, Ball zu fest aufgepumpt
+- **Sicherheit**: Langsam und kontrolliert hinlegen, nicht auf dem Ball einschlafen
+- **Tempo**: Keine aktive Bewegung nötig, Entspannung im Vordergrund
+
+## Variationen
+
+- **Variation 1**: Ball unter die Schulterblätter – öffnet den Brustkorb
+- **Variation 2**: Ball unter eine Gesäßhälfte – dehnt den Piriformis
+
+## Verwandte Übungen
+
+- [Katze-Kuh](./katze_kuh.md)
+- [Atemübung mit Armen](./atemuebung_mit_armen.md)
+- [Seitliche Rumpfdehnung im Sitzen](./seitliche_rumpfdehnung_im_sitzen.md)
+
+## Wissenswertes
+
+Der Redondo-Ball übt einen sanften Druck auf die Muskulatur aus, ähnlich einer Selbstmassage. Dieser Druck fördert die Durchblutung und kann myofasziale Triggerpunkte lösen. Die Entspannung nach dem Training unterstützt die Regeneration und bereitet den Körper auf den Alltag vor.
+
+## Wird verwendet in
+
+- [Stunde: Stab & Redondo-Ball](../stunden/ruecken/stab-und-redondo.md)
+
+---
+**Tags**: #ausklang #beweglichkeit #entspannung #regeneration #redondo
+**Erstellt**: 02.12.2025
+**Letzte Änderung**: 02.12.2025

--- a/Übungen/redondo_rueckenmobilisation.md
+++ b/Übungen/redondo_rueckenmobilisation.md
@@ -1,0 +1,92 @@
+# Redondo-Ball Rückenmobilisation
+
+## Kategorie
+
+- **Bereich**: Aufwärmen
+- **Schwerpunkt**: Beweglichkeit
+- **Dauer**: 3 Minuten
+- **Schwierigkeitsgrad**: Leicht
+
+## Beschreibung
+
+Sanfte Mobilisation der Wirbelsäule durch Rollen auf dem Redondo-Ball in Rückenlage. Der weiche Ball passt sich der Wirbelsäulenform an und ermöglicht eine segmentale Mobilisation. Ideal zum Lösen von Verspannungen und als Einstieg in die Trainingseinheit.
+
+## Ausführung
+
+1. Rückenlage, Beine aufgestellt, Füße hüftbreit am Boden.
+2. Redondo-Ball unter die Lendenwirbelsäule legen (Höhe Bauchnabel).
+3. Becken langsam nach rechts und links kippen, Ball rollt mit.
+4. Anschließend Ball unter die Brustwirbelsäule schieben und Bewegung wiederholen.
+5. 10-12 langsame Kippbewegungen pro Position.
+
+## Zielmuskulatur
+
+- **Primär**: Autochthone Rückenmuskulatur, paravertebrale Muskulatur
+- **Sekundär**: Bauchmuskulatur (stabilisierend), Gesäßmuskulatur
+
+## Hilfsmittel
+
+- Redondo-Ball (ca. 22-26 cm Durchmesser)
+
+## Geeignet für
+
+- Teilnehmer mit Rückenverspannungen
+- Personen mit eingeschränkter Wirbelsäulenbeweglichkeit
+- **Besonders empfohlen bei**: Morgensteifigkeit, unspezifischen Rückenschmerzen, nach langem Sitzen
+
+## Nicht geeignet für / Kontraindikationen
+
+- ⚠️ **Nicht bei akuten Verletzungen**: Akute Bandscheibenvorfälle, frische Wirbelfrakturen
+- ⚠️ **Vorsicht bei**: Starke Osteoporose, Spinalkanalstenose
+- ⚠️ **Kontraindiziert bei**: Akute Entzündungen der Wirbelsäule, instabile Wirbelkörper
+
+## Alternativen
+
+### Bei Knieproblemen 🦵
+
+- **Alternative Übung**: Beine gestreckt ablegen oder auf Kissen lagern
+- **Anpassung**: Knie mit Kissen unterstützen, weniger Beugung
+- **Hinweis**: Hauptbewegung bleibt im Rumpf, Knie werden entlastet
+
+### Bei Schulterproblemen 💪
+
+- **Alternative Übung**: Arme entspannt neben dem Körper ablegen
+- **Anpassung**: Keine Überkopfbewegungen, Schultern bleiben entspannt
+- **Hinweis**: Fokus auf Wirbelsäulenbewegung, Schultern nicht beteiligt
+
+### Weitere Anpassungen
+
+- **Vereinfachung (Anfänger)**: Ball weniger aufpumpen (weicher), kleinere Bewegungen
+- **Steigerung (Fortgeschrittene)**: Ball fester aufpumpen, größerer Bewegungsradius
+- **Für Senioren**: Ball sehr weich, Unterstützung beim Hinlegen, ggf. Kopfkissen
+
+## Wichtige Hinweise
+
+- **Atmung**: Ruhig und gleichmäßig atmen, Bewegung mit Ausatmung einleiten
+- **Häufige Fehler**: Zu schnelle Bewegung, Anspannung statt Entspannung, Ball zu fest aufgepumpt
+- **Sicherheit**: Langsam hinlegen und aufstehen, Ball sollte nicht wegrutschen
+- **Tempo**: Sehr langsam, 3-4 Sekunden pro Kippbewegung
+
+## Variationen
+
+- **Variation 1**: Ball unter dem Kreuzbein – sanftes Beckenschaukeln
+- **Variation 2**: Kreisende Beckenbewegungen auf dem Ball
+
+## Verwandte Übungen
+
+- [Katze-Kuh](./katze_kuh.md)
+- [Beckenlift](./beckenlift.md)
+- [Knie zur Brust](./knie_zur_brust.md)
+
+## Wissenswertes
+
+Der Redondo-Ball wurde ursprünglich für die Pilates-Methode entwickelt. Seine weiche, nachgebende Oberfläche ermöglicht eine sanfte propriozeptive Stimulation der Rückenmuskulatur. Die instabile Unterlage aktiviert automatisch die tiefe Rumpfmuskulatur.
+
+## Wird verwendet in
+
+- [Stunde: Stab & Redondo-Ball](../stunden/ruecken/stab-und-redondo.md)
+
+---
+**Tags**: #aufwärmen #beweglichkeit #rücken #redondo #mobilisation
+**Erstellt**: 02.12.2025
+**Letzte Änderung**: 02.12.2025

--- a/Übungen/redondo_rumpfstabilisation.md
+++ b/Übungen/redondo_rumpfstabilisation.md
@@ -1,0 +1,92 @@
+# Redondo-Ball Rumpfstabilisation
+
+## Kategorie
+
+- **Bereich**: Schwerpunkt
+- **Schwerpunkt**: Kraft
+- **Dauer**: 5 Minuten
+- **Schwierigkeitsgrad**: Mittel
+
+## Beschreibung
+
+Intensive Kräftigungsübung für die tiefe Rumpfmuskulatur. Der Redondo-Ball wird zwischen den Knien oder Unterschenkeln gehalten, während in Rückenlage verschiedene Beinbewegungen ausgeführt werden. Die instabile Unterlage aktiviert zusätzlich die stabilisierende Muskulatur.
+
+## Ausführung
+
+1. Rückenlage, Kopf entspannt, Arme neben dem Körper.
+2. Beine anheben, Knie 90° gebeugt (Tischposition), Redondo-Ball zwischen die Knie klemmen.
+3. Ball leicht zusammendrücken, Bauchnabel zur Wirbelsäule ziehen.
+4. Beide Beine kontrolliert Richtung Boden absenken, ohne Bodenkontakt.
+5. Zurück zur Ausgangsposition. 10-12 Wiederholungen, 2-3 Sätze.
+
+## Zielmuskulatur
+
+- **Primär**: Transversus abdominis, gerader Bauchmuskel, Hüftbeuger
+- **Sekundär**: Adduktoren (Zusammendrücken), Beckenboden, schräge Bauchmuskulatur
+
+## Hilfsmittel
+
+- Redondo-Ball (ca. 22-26 cm Durchmesser)
+
+## Geeignet für
+
+- Teilnehmer mit Rückenproblemen (Core-Stabilität als Schutz)
+- Personen mit schwacher Bauchmuskulatur
+- **Besonders empfohlen bei**: Instabilität der Lendenwirbelsäule, Prävention von Rückenschmerzen
+
+## Nicht geeignet für / Kontraindikationen
+
+- ⚠️ **Nicht bei akuten Verletzungen**: Akute Bandscheibenvorfälle, Leistenbruch, akute Bauchoperationen
+- ⚠️ **Vorsicht bei**: Rektusdiastase, Bluthochdruck (nicht pressen)
+- ⚠️ **Kontraindiziert bei**: Akute Entzündungen im Bauchraum, schwerer Beckenbodenschwäche
+
+## Alternativen
+
+### Bei Knieproblemen 🦵
+
+- **Alternative Übung**: Ball zwischen die Unterschenkel (oberhalb der Knöchel) klemmen
+- **Anpassung**: Kniewinkel vergrößern, weniger Druck auf den Ball
+- **Hinweis**: Bei starken Knieproblemen: Füße aufgestellt lassen, nur Beckenkippung
+
+### Bei Schulterproblemen 💪
+
+- **Alternative Übung**: Arme auf Kissen lagern statt am Boden
+- **Anpassung**: Keine Armbewegungen, Schultern entspannt
+- **Hinweis**: Diese Übung belastet die Schultern minimal
+
+### Weitere Anpassungen
+
+- **Vereinfachung (Anfänger)**: Füße bleiben am Boden, nur Ball zusammendrücken und Beckenkippung
+- **Steigerung (Fortgeschrittene)**: Beine strecken, Hände hinter dem Kopf
+- **Für Senioren**: Beine nur leicht abheben, kleinerer Bewegungsradius
+
+## Wichtige Hinweise
+
+- **Atmung**: Ausatmen beim Absenken der Beine, Einatmen beim Anheben. Nicht die Luft anhalten!
+- **Häufige Fehler**: Hohlkreuz beim Absenken, Luft anhalten, Ball fällt aus den Knien
+- **Sicherheit**: Lendenwirbelsäule bleibt am Boden – Beine nur so weit senken wie Kontakt gehalten werden kann
+- **Tempo**: Langsam und kontrolliert, 3 Sekunden absenken, 2 Sekunden halten, 2 Sekunden anheben
+
+## Variationen
+
+- **Variation 1**: Beine diagonal bewegen (Fahrrad-ähnlich mit Ball)
+- **Variation 2**: Ball zwischen Unterschenkel – Beine strecken und beugen
+
+## Verwandte Übungen
+
+- [Beckenlift](./beckenlift.md)
+- [Oberkörper heben (Bauch)](./oberkörper_heben_bauch.md)
+- [Planke an der Wand](./planke_an_der_wand.md)
+
+## Wissenswertes
+
+Das Zusammendrücken des Balls aktiviert die Adduktoren, die über fasziale Verbindungen mit der tiefen Bauchmuskulatur verbunden sind. Diese Co-Kontraktion verstärkt die Rumpfstabilisation erheblich. Der Redondo-Ball ist weich genug, um angenehm zu sein, aber fest genug für effektives Training.
+
+## Wird verwendet in
+
+- [Stunde: Stab & Redondo-Ball](../stunden/ruecken/stab-und-redondo.md)
+
+---
+**Tags**: #schwerpunkt #kraft #core #bauch #redondo #stabilisation
+**Erstellt**: 02.12.2025
+**Letzte Änderung**: 02.12.2025

--- a/Übungen/stab_brustdehnung.md
+++ b/Übungen/stab_brustdehnung.md
@@ -1,0 +1,91 @@
+# Stab-Brustdehnung
+
+## Kategorie
+
+- **Bereich**: Ausklang
+- **Schwerpunkt**: Beweglichkeit
+- **Dauer**: 3 Minuten
+- **Schwierigkeitsgrad**: Leicht
+
+## Beschreibung
+
+Sanfte Dehnübung für die Brustmuskulatur und die vordere Schulterpartie unter Verwendung eines Stabes. Der Stab wird hinter dem Rücken gehalten und nach oben geführt, wodurch eine angenehme Dehnung der Brustmuskulatur entsteht. Idealer Abschluss nach Kräftigungsübungen.
+
+## Ausführung
+
+1. Hüftbreiter Stand, aufrechte Haltung, Schultern entspannt.
+2. Stab hinter dem Rücken greifen, Handflächen zeigen nach hinten, Griff schulterbreit oder breiter.
+3. Arme bleiben gestreckt, Stab langsam vom Körper weg nach hinten-oben führen.
+4. Position halten, wenn angenehme Dehnung in Brust und Schultern spürbar ist.
+5. 20-30 Sekunden halten, dann lösen. 3 Wiederholungen.
+
+## Zielmuskulatur
+
+- **Primär**: Großer Brustmuskel (M. pectoralis major), vorderer Deltamuskel
+- **Sekundär**: Kleiner Brustmuskel (M. pectoralis minor), Bizeps
+
+## Hilfsmittel
+
+- Gymnastikstab (ca. 100-120 cm)
+
+## Geeignet für
+
+- Teilnehmer mit verkürzter Brustmuskulatur
+- Personen mit Rundrücken oder Schreibtischhaltung
+- **Besonders empfohlen bei**: Haltungsschwäche, Schulter-Nacken-Verspannungen, nach Brustmuskeltraining
+
+## Nicht geeignet für / Kontraindikationen
+
+- ⚠️ **Nicht bei akuten Verletzungen**: Akute Schulterluxation, frische Brustmuskelzerrung
+- ⚠️ **Vorsicht bei**: Schulterinstabilität, Impingement-Syndrom
+- ⚠️ **Kontraindiziert bei**: Akuter Sehnenentzündung der Schulter, Z.n. Schulter-OP (Rücksprache mit Arzt)
+
+## Alternativen
+
+### Bei Knieproblemen 🦵
+
+- **Alternative Übung**: Im Sitzen auf Stuhl ausführen
+- **Anpassung**: Gleiche Armposition, Rücken frei vom Stuhl
+- **Hinweis**: Dehnung bleibt unverändert effektiv
+
+### Bei Schulterproblemen 💪
+
+- **Alternative Übung**: Brustdehnung an der Wand (einarmig)
+- **Anpassung**: Griffbreite deutlich vergrößern, Bewegungsumfang reduzieren
+- **Hinweis**: Bei Schmerzen sofort abbrechen, alternative Brustdehnung im Türrahmen nutzen
+
+### Weitere Anpassungen
+
+- **Vereinfachung (Anfänger)**: Breiterer Griff am Stab, kleinerer Bewegungsumfang
+- **Steigerung (Fortgeschrittene)**: Engerer Griff, längere Haltezeit
+- **Für Senioren**: Stab tiefer halten, sanfte Dehnung ohne Maximalposition
+
+## Wichtige Hinweise
+
+- **Atmung**: Ruhig und gleichmäßig weiteratmen, nicht die Luft anhalten
+- **Häufige Fehler**: Hohlkreuz, Schultern hochziehen, zu schnelle Bewegung
+- **Sicherheit**: Nur bis zur angenehmen Dehnung gehen, kein Schmerz
+- **Tempo**: Sehr langsam in die Dehnung gehen, mindestens 20 Sekunden halten
+
+## Variationen
+
+- **Variation 1**: Stab überm Kopf halten und nach hinten führen (nur bei sehr guter Mobilität)
+- **Variation 2**: Wechselseitige Dehnung – Stab diagonal halten
+
+## Verwandte Übungen
+
+- [Brustdehnung an der Wand](./brustdehnung_wand.md)
+- [Atemübung mit Armen](./atemuebung_mit_armen.md)
+
+## Wissenswertes
+
+Eine verkürzte Brustmuskulatur zieht die Schultern nach vorne und fördert einen Rundrücken. Regelmäßiges Dehnen der Brustmuskulatur ist daher wichtig für eine aufrechte Haltung. Der Stab ermöglicht eine gleichmäßige, symmetrische Dehnung beider Seiten.
+
+## Wird verwendet in
+
+- [Stunde: Stab & Redondo-Ball](../stunden/ruecken/stab-und-redondo.md)
+
+---
+**Tags**: #ausklang #beweglichkeit #brust #schulter #stab #dehnung
+**Erstellt**: 02.12.2025
+**Letzte Änderung**: 02.12.2025

--- a/Übungen/stab_rotation_im_stand.md
+++ b/Übungen/stab_rotation_im_stand.md
@@ -1,0 +1,91 @@
+# Stab-Rotation im Stand
+
+## Kategorie
+
+- **Bereich**: Aufwärmen
+- **Schwerpunkt**: Beweglichkeit
+- **Dauer**: 3 Minuten
+- **Schwierigkeitsgrad**: Mittel
+
+## Beschreibung
+
+Sanfte Rotationsbewegung der Brustwirbelsäule mit einem Stab auf den Schultern. Der Stab dient als Orientierungshilfe und verstärkt das Bewusstsein für die Rotationsbewegung. Ideal zur Mobilisierung der oft eingeschränkten Brustwirbelsäule.
+
+## Ausführung
+
+1. Hüftbreiter Stand, Knie leicht gebeugt, Stab liegt auf den Schultern hinter dem Nacken.
+2. Hände greifen den Stab schulterbreit, Ellbogen zeigen nach außen.
+3. Becken bleibt stabil nach vorne gerichtet, nur der Oberkörper rotiert.
+4. Langsam zur rechten Seite drehen, kurz halten, dann zur linken Seite.
+5. Bewegung aus der Brustwirbelsäule initiieren, nicht aus der Lendenwirbelsäule.
+
+## Zielmuskulatur
+
+- **Primär**: Rotatoren der Brustwirbelsäule (M. multifidus, Mm. rotatores), schräge Bauchmuskulatur
+- **Sekundär**: Autochthone Rückenmuskulatur, Schulterblattfixatoren
+
+## Hilfsmittel
+
+- Gymnastikstab (ca. 100-120 cm)
+
+## Geeignet für
+
+- Teilnehmer mit Bewegungseinschränkungen in der Brustwirbelsäule
+- Personen mit Büroarbeitsplatz
+- **Besonders empfohlen bei**: Verspannungen im oberen Rücken, Hyperkyphose, eingeschränkter Rotationsfähigkeit
+
+## Nicht geeignet für / Kontraindikationen
+
+- ⚠️ **Nicht bei akuten Verletzungen**: Akute Bandscheibenvorfälle, frische Wirbelkörperfrakturen
+- ⚠️ **Vorsicht bei**: Instabilität der Wirbelsäule, fortgeschrittener Osteoporose
+- ⚠️ **Kontraindiziert bei**: Akuter Bandscheibenprotrusion mit Nervenwurzelkompression, Wirbelgleiten (Spondylolisthesis) Grad III-IV
+
+## Alternativen
+
+### Bei Knieproblemen 🦵
+
+- **Alternative Übung**: Im Sitzen auf Stuhl ausführen
+- **Anpassung**: Füße flach am Boden, Sitzbeinhöcker als Fixpunkt
+- **Hinweis**: Gleiche Rotationsbewegung, Becken bleibt stabil auf dem Stuhl
+
+### Bei Schulterproblemen 💪
+
+- **Alternative Übung**: Stab vor der Brust halten
+- **Anpassung**: Stab mit gestreckten Armen vor der Brust halten, Ellbogen leicht gebeugt
+- **Hinweis**: Reduziert die Belastung des Schultergelenks erheblich
+
+### Weitere Anpassungen
+
+- **Vereinfachung (Anfänger)**: Kleinerer Rotationsradius, langsames Tempo
+- **Steigerung (Fortgeschrittene)**: Größerer Rotationsradius, am Endpunkt 3 Sekunden halten
+- **Für Senioren**: Im Sitzen ausführen, Handtuch statt Stab verwenden
+
+## Wichtige Hinweise
+
+- **Atmung**: Ausatmen während der Rotation, Einatmen beim Zurückkommen zur Mitte
+- **Häufige Fehler**: Becken dreht mit, Lendenwirbelsäule übernimmt Bewegung, Schultern hochgezogen
+- **Sicherheit**: Stab nicht in den Nacken drücken, nur locker auflegen
+- **Tempo**: Langsam und kontrolliert, 2-3 Sekunden pro Richtung
+
+## Variationen
+
+- **Variation 1**: Stab vor der Brust mit gestreckten Armen – erhöht den Hebel
+- **Variation 2**: Im Einbeinstand – zusätzliche Balance-Herausforderung
+
+## Verwandte Übungen
+
+- [Rumpfrotation im Stand](./rumpfrotation_im_stand.md)
+- [Rumpfrotation mit Gewicht](./rumpfrotation_mit_gewicht.md)
+
+## Wissenswertes
+
+Die Brustwirbelsäule ist anatomisch für Rotation ausgelegt (bis zu 35° pro Seite), wird aber durch sitzende Tätigkeiten oft steif. Der Stab gibt visuelles und propriozeptives Feedback über die Bewegungsqualität und hilft, kompensatorische Bewegungen der Lendenwirbelsäule zu vermeiden.
+
+## Wird verwendet in
+
+- [Stunde: Stab & Redondo-Ball](../stunden/ruecken/stab-und-redondo.md)
+
+---
+**Tags**: #aufwärmen #beweglichkeit #brustwirbelsäule #stab #rotation
+**Erstellt**: 02.12.2025
+**Letzte Änderung**: 02.12.2025

--- a/Übungen/stab_schultermobilisation.md
+++ b/Übungen/stab_schultermobilisation.md
@@ -1,0 +1,92 @@
+# Stab-Schultermobilisation
+
+## Kategorie
+
+- **Bereich**: Hauptteil
+- **Schwerpunkt**: Beweglichkeit
+- **Dauer**: 4 Minuten
+- **Schwierigkeitsgrad**: Mittel
+
+## Beschreibung
+
+Dynamische Übung zur Verbesserung der Schulterbeweglichkeit und Kräftigung der Schulterblattmuskulatur. Der Stab wird mit gestreckten Armen vor dem Körper gehalten und in verschiedenen Bewegungsebenen geführt. Fördert die aufrechte Haltung und mobilisiert den gesamten Schultergürtel.
+
+## Ausführung
+
+1. Hüftbreiter Stand, Knie leicht gebeugt, Stab mit beiden Händen schulterbreit greifen.
+2. Stab mit gestreckten Armen auf Brusthöhe halten, Schultern tief.
+3. Stab langsam über den Kopf führen, Arme bleiben gestreckt.
+4. Am höchsten Punkt kurz halten, dann kontrolliert absenken.
+5. 10-12 Wiederholungen, dann Variation: Stab seitlich nach rechts/links führen.
+
+## Zielmuskulatur
+
+- **Primär**: Deltamuskel (M. deltoideus), Trapezmuskel (M. trapezius), Rhomboiden
+- **Sekundär**: Rotatorenmanschette, vorderer Sägemuskel (M. serratus anterior)
+
+## Hilfsmittel
+
+- Gymnastikstab (ca. 100-120 cm)
+
+## Geeignet für
+
+- Teilnehmer mit eingeschränkter Schulterbeweglichkeit
+- Personen mit Rundrücken-Tendenz
+- **Besonders empfohlen bei**: Schulterverspannungen, Haltungsschwäche, Impingement-Prävention
+
+## Nicht geeignet für / Kontraindikationen
+
+- ⚠️ **Nicht bei akuten Verletzungen**: Akute Schulterluxation, frische Rotatorenmanschettenruptur
+- ⚠️ **Vorsicht bei**: Schulterimpingement (Bewegungsumfang anpassen), Frozen Shoulder
+- ⚠️ **Kontraindiziert bei**: Akuter Schleimbeutelentzündung der Schulter, instabiler Schulter nach Luxation
+
+## Alternativen
+
+### Bei Knieproblemen 🦵
+
+- **Alternative Übung**: Im Sitzen auf Stuhl ausführen
+- **Anpassung**: Gleiche Armbewegung, Rücken an Stuhllehne
+- **Hinweis**: Fokus auf Schulterarbeit bleibt erhalten
+
+### Bei Schulterproblemen 💪
+
+- **Alternative Übung**: Stab nur bis Schulterhöhe heben
+- **Anpassung**: Bewegungsradius auf schmerzfreien Bereich reduzieren, Griffbreite vergrößern
+- **Hinweis**: Lieber kleiner Bewegungsumfang als Schmerzen. Bei Impingement: nicht über 90° Abduktion
+
+### Weitere Anpassungen
+
+- **Vereinfachung (Anfänger)**: Stab nur bis Kinnhöhe, breiterer Griff
+- **Steigerung (Fortgeschrittene)**: Stab hinter den Kopf führen (nur bei guter Mobilität)
+- **Für Senioren**: Im Sitzen, kleinerer Bewegungsradius, leichterer Stab
+
+## Wichtige Hinweise
+
+- **Atmung**: Einatmen beim Heben, Ausatmen beim Senken
+- **Häufige Fehler**: Schultern hochziehen, Hohlkreuz beim Überkopfheben, Ellbogen beugen
+- **Sicherheit**: Bei Schmerzen Bewegungsumfang sofort reduzieren
+- **Tempo**: Langsam und kontrolliert, 3 Sekunden heben, 3 Sekunden senken
+
+## Variationen
+
+- **Variation 1**: Diagonales Heben – Stab von rechts unten nach links oben führen
+- **Variation 2**: Horizontale Rotation – Stab auf Brusthöhe halten und horizontal drehen
+
+## Verwandte Übungen
+
+- [Schulterkreisen](./schulterkreisen.md)
+- [Armkreisen](./armkreisen.md)
+- [Armheben mit Widerstand](./armheben_mit_widerstand.md)
+
+## Wissenswertes
+
+Die Schultermobilität ist entscheidend für viele Alltagsbewegungen. Der Stab erzwingt eine symmetrische Bewegung beider Arme und deckt Seitenunterschiede auf. Bei regelmäßiger Durchführung verbessert sich nicht nur die Beweglichkeit, sondern auch die Haltung durch Kräftigung der Schulterblattfixatoren.
+
+## Wird verwendet in
+
+- [Stunde: Stab & Redondo-Ball](../stunden/ruecken/stab-und-redondo.md)
+
+---
+**Tags**: #hauptteil #beweglichkeit #schulter #stab #mobilisation
+**Erstellt**: 02.12.2025
+**Letzte Änderung**: 02.12.2025

--- a/Übungen/stab_seitneigung.md
+++ b/Übungen/stab_seitneigung.md
@@ -1,0 +1,92 @@
+# Stab-Seitneigung
+
+## Kategorie
+
+- **Bereich**: Schwerpunkt
+- **Schwerpunkt**: Kraft
+- **Dauer**: 4 Minuten
+- **Schwierigkeitsgrad**: Mittel
+
+## Beschreibung
+
+Kräftigende Übung für die seitliche Rumpfmuskulatur mit dem Stab als Führungshilfe. Der Stab auf den Schultern gibt visuelle Orientierung und verstärkt die Dehnung der Gegenseite. Trainiert die laterale Rumpfkette und verbessert die seitliche Rumpfstabilität.
+
+## Ausführung
+
+1. Hüftbreiter Stand, Stab liegt auf den Schultern hinter dem Nacken.
+2. Hände greifen den Stab schulterbreit, Ellbogen zeigen nach außen.
+3. Oberkörper langsam zur rechten Seite neigen, Stab bleibt parallel zum Boden.
+4. In der Endposition 2 Sekunden halten, dann zurück zur Mitte.
+5. Zur linken Seite wiederholen. 10-12 Wiederholungen pro Seite.
+
+## Zielmuskulatur
+
+- **Primär**: Schräge Bauchmuskulatur (M. obliquus externus/internus), Quadratus lumborum
+- **Sekundär**: Rückenstrecker (M. erector spinae), Interkostalmuskulatur
+
+## Hilfsmittel
+
+- Gymnastikstab (ca. 100-120 cm)
+
+## Geeignet für
+
+- Teilnehmer mit schwacher seitlicher Rumpfmuskulatur
+- Personen mit einseitigen Belastungen im Alltag
+- **Besonders empfohlen bei**: Rückenschmerzen durch muskuläre Dysbalancen, Skoliose-Prävention
+
+## Nicht geeignet für / Kontraindikationen
+
+- ⚠️ **Nicht bei akuten Verletzungen**: Akute Rippenverletzungen, frische Bandscheibenvorfälle
+- ⚠️ **Vorsicht bei**: Ausgeprägte Skoliose, Osteoporose mit Frakturrisiko
+- ⚠️ **Kontraindiziert bei**: Akuter lateraler Bandscheibenvorfall, instabile Wirbelsäule
+
+## Alternativen
+
+### Bei Knieproblemen 🦵
+
+- **Alternative Übung**: Im Sitzen auf Stuhl ausführen
+- **Anpassung**: Füße flach am Boden, Becken fixiert auf Sitzfläche
+- **Hinweis**: Gleiche Bewegung, reduzierte Anforderung an Knie und Balance
+
+### Bei Schulterproblemen 💪
+
+- **Alternative Übung**: Stab vor der Brust halten oder Hände an die Hüften
+- **Anpassung**: Stab mit gebeugten Ellbogen vor der Brust halten
+- **Hinweis**: Alternativ ganz ohne Stab mit Händen an der Hüfte
+
+### Weitere Anpassungen
+
+- **Vereinfachung (Anfänger)**: Kleinerer Neigungswinkel, ohne Haltezeit
+- **Steigerung (Fortgeschrittene)**: Haltezeit auf 5 Sekunden erhöhen, leichte Zusatzgewichte am Stab
+- **Für Senioren**: Im Sitzen, Stab vor der Brust, sanfte Bewegung
+
+## Wichtige Hinweise
+
+- **Atmung**: Einatmen in der Mitte, Ausatmen bei der Seitneigung
+- **Häufige Fehler**: Becken kippt mit, Schultern werden hochgezogen, Rotation statt reine Seitneigung
+- **Sicherheit**: Stab nur locker auf Schultern legen, nicht in den Nacken drücken
+- **Tempo**: Langsam und kontrolliert, 2 Sekunden pro Phase
+
+## Variationen
+
+- **Variation 1**: Mit Ausfallschritt – ein Bein seitlich aufgestellt für mehr Dehnung
+- **Variation 2**: Dynamisches Wippen in der Endposition (nur für Fortgeschrittene)
+
+## Verwandte Übungen
+
+- [Seitneigung mit Armheben](./seitneigung_armheben.md)
+- [Seitliche Rumpfdehnung im Sitzen](./seitliche_rumpfdehnung_im_sitzen.md)
+- [Seitstütz (Knie modifiziert)](./seitstütz_knie_modifiziert.md)
+
+## Wissenswertes
+
+Die seitliche Rumpfmuskulatur wird im Alltag oft vernachlässigt, ist aber essenziell für die Stabilisierung der Wirbelsäule bei asymmetrischen Belastungen (Tragen von Taschen, einseitige Arbeit). Der Stab macht sofort sichtbar, ob die Bewegung symmetrisch ausgeführt wird.
+
+## Wird verwendet in
+
+- [Stunde: Stab & Redondo-Ball](../stunden/ruecken/stab-und-redondo.md)
+
+---
+**Tags**: #schwerpunkt #kraft #rumpf #stab #seitneigung
+**Erstellt**: 02.12.2025
+**Letzte Änderung**: 02.12.2025

--- a/Übungen/ÜBUNGSINDEX.md
+++ b/Übungen/ÜBUNGSINDEX.md
@@ -4,8 +4,8 @@
 
 Dieser Index listet alle dokumentierten Übungen sortiert nach Kategorien. Nutzen Sie diesen Index, um schnell passende Übungen für Ihre Stunden zu finden.
 
-**Stand**: 13.11.2025  
-**Anzahl Übungen gesamt**: 37
+**Stand**: 02.12.2025
+**Anzahl Übungen gesamt**: 45
 
 ---
 
@@ -26,6 +26,8 @@ Dieser Index listet alle dokumentierten Übungen sortiert nach Kategorien. Nutze
 | Hampelmann (modifiziert) | Ausdauer | 1-2 Min | Leicht | [hampelmann_modifiziert.md](hampelmann_modifiziert.md) |
 | Fersen- und Zehenstand | Balance | 1-2 Min | Leicht | [fersen_und_zehenstand.md](fersen_und_zehenstand.md) |
 | Rumpfrotation im Stand | Beweglichkeit | 1-2 Min | Leicht | [rumpfrotation_im_stand.md](rumpfrotation_im_stand.md) |
+| Stab-Rotation im Stand | Beweglichkeit | 3 Min | Mittel | [stab_rotation_im_stand.md](stab_rotation_im_stand.md) |
+| Redondo-Ball Rückenmobilisation | Beweglichkeit | 3 Min | Leicht | [redondo_rueckenmobilisation.md](redondo_rueckenmobilisation.md) |
 
 ---
 
@@ -46,6 +48,8 @@ Dieser Index listet alle dokumentierten Übungen sortiert nach Kategorien. Nutze
 | Beinpendel seitlich | Kraft | 2-3 Min | Leicht | [beinpendel_seitlich.md](beinpendel_seitlich.md) |
 | Armheben mit Widerstand | Kraft | 2-3 Min | Leicht | [armheben_mit_widerstand.md](armheben_mit_widerstand.md) |
 | Oberkörper heben (Bauch) | Kraft | 2-3 Min | Leicht | [oberkörper_heben_bauch.md](oberkörper_heben_bauch.md) |
+| Stab-Schultermobilisation | Beweglichkeit | 4 Min | Mittel | [stab_schultermobilisation.md](stab_schultermobilisation.md) |
+| Redondo-Ball Beckenkippung | Koordination | 4 Min | Mittel | [redondo_beckenkippung.md](redondo_beckenkippung.md) |
 
 ---
 
@@ -65,6 +69,8 @@ Intensive, themenspezifische Übungen
 | Seitstütz Knie (modifiziert) | Kraft | 2-3 Min | Mittel | [seitstütz_knie_modifiziert.md](seitstütz_knie_modifiziert.md) |
 | Rumpfrotation mit Gewicht | Kraft | 2-3 Min | Mittel | [rumpfrotation_mit_gewicht.md](rumpfrotation_mit_gewicht.md) |
 | Tandemstand | Balance | 2-3 Min | Mittel | [tandemstand.md](tandemstand.md) |
+| Stab-Seitneigung | Kraft | 4 Min | Mittel | [stab_seitneigung.md](stab_seitneigung.md) |
+| Redondo-Ball Rumpfstabilisation | Kraft | 5 Min | Mittel | [redondo_rumpfstabilisation.md](redondo_rumpfstabilisation.md) |
 
 ---
 
@@ -80,6 +86,8 @@ Intensive, themenspezifische Übungen
 | Brustdehnung an der Wand | Beweglichkeit | 2-3 Min | Leicht | [brustdehnung_an_der_wand.md](brustdehnung_an_der_wand.md) |
 | Seitliche Rumpfdehnung im Sitzen | Beweglichkeit | 2-3 Min | Leicht | [seitliche_rumpfdehnung_im_sitzen.md](seitliche_rumpfdehnung_im_sitzen.md) |
 | Atemübung mit Armen | Beweglichkeit | 2-3 Min | Leicht | [atemübung_mit_armen.md](atemübung_mit_armen.md) |
+| Stab-Brustdehnung | Beweglichkeit | 3 Min | Leicht | [stab_brustdehnung.md](stab_brustdehnung.md) |
+| Redondo-Ball Entspannung | Beweglichkeit | 3 Min | Leicht | [redondo_entspannung.md](redondo_entspannung.md) |
 
 ---
 
@@ -104,6 +112,8 @@ Intensive, themenspezifische Übungen
 - [Wadenheben einbeinig](wadenheben_einbeinig.md)
 - [Seitstütz Knie (modifiziert)](seitstütz_knie_modifiziert.md)
 - [Rumpfrotation mit Gewicht](rumpfrotation_mit_gewicht.md)
+- [Stab-Seitneigung](stab_seitneigung.md)
+- [Redondo-Ball Rumpfstabilisation](redondo_rumpfstabilisation.md)
 
 ### Beweglichkeit
 
@@ -121,6 +131,11 @@ Intensive, themenspezifische Übungen
 - [Brustdehnung an der Wand](brustdehnung_an_der_wand.md)
 - [Seitliche Rumpfdehnung im Sitzen](seitliche_rumpfdehnung_im_sitzen.md)
 - [Atemübung mit Armen](atemübung_mit_armen.md)
+- [Stab-Rotation im Stand](stab_rotation_im_stand.md)
+- [Stab-Schultermobilisation](stab_schultermobilisation.md)
+- [Stab-Brustdehnung](stab_brustdehnung.md)
+- [Redondo-Ball Rückenmobilisation](redondo_rueckenmobilisation.md)
+- [Redondo-Ball Entspannung](redondo_entspannung.md)
 
 ### Ausdauer
 
@@ -130,6 +145,7 @@ Intensive, themenspezifische Übungen
 ### Koordination
 
 - [Vogel-Hund (Vierfüßlerstand)](vogel_hund.md)
+- [Redondo-Ball Beckenkippung](redondo_beckenkippung.md)
 
 ### Balance
 
@@ -396,6 +412,20 @@ Intensive, themenspezifische Übungen
 - [Kreuzheben mit Wasserflasche](kreuzheben_mit_wasserflasche.md) - Wasserflaschen
 - [Rumpfrotation mit Gewicht](rumpfrotation_mit_gewicht.md) - Wasserflaschen
 
+### Mit Gymnastikstab
+
+- [Stab-Rotation im Stand](stab_rotation_im_stand.md) - Brustwirbelsäulen-Mobilisation
+- [Stab-Schultermobilisation](stab_schultermobilisation.md) - Schulter-Beweglichkeit
+- [Stab-Seitneigung](stab_seitneigung.md) - Seitliche Rumpfkraft
+- [Stab-Brustdehnung](stab_brustdehnung.md) - Brust- und Schulterdehnung
+
+### Mit Redondo-Ball
+
+- [Redondo-Ball Rückenmobilisation](redondo_rueckenmobilisation.md) - Wirbelsäulen-Mobilisation
+- [Redondo-Ball Beckenkippung](redondo_beckenkippung.md) - Beckenkontrolle
+- [Redondo-Ball Rumpfstabilisation](redondo_rumpfstabilisation.md) - Core-Kräftigung
+- [Redondo-Ball Entspannung](redondo_entspannung.md) - Regeneration
+
 ---
 
 ## 📊 Verwendung in Stunden
@@ -444,44 +474,52 @@ Intensive, themenspezifische Übungen
 
 ## 🆕 Neueste Übungen
 
-1. **Atemübung mit Armen** - 13.11.2025 - Entspannung und bewusste Atmung
-2. **Seitliche Rumpfdehnung im Sitzen** - 13.11.2025 - Seitliche Flanken dehnen
-3. **Brustdehnung an der Wand** - 13.11.2025 - Brust und vordere Schulter
-4. **Dehnung Hüftbeuger** - 13.11.2025 - Hüftbeugemuskulatur
-5. **Dehnung Oberschenkelrückseite** - 13.11.2025 - Hamstrings dehnen
-6. **Tandemstand** - 13.11.2025 - Gleichgewicht und Gangstabilität
-7. **Rumpfrotation mit Gewicht** - 13.11.2025 - Rotationskraft
-8. **Seitstütz Knie (modifiziert)** - 13.11.2025 - Seitliche Rumpfkraft
-9. **Wadenheben einbeinig** - 13.11.2025 - Wadenmuskulatur intensiv
-10. **Vogel-Hund (Vierfüßlerstand)** - 13.11.2025 - Koordination und Rumpfstabilität
-11. **Schulterbrücke einbeinig** - 13.11.2025 - Gesäßkraft intensiv
-12. **Seitlicher Ausfallschritt** - 13.11.2025 - Multidimensionale Beinkraft
-13. **Kreuzheben mit Wasserflasche** - 13.11.2025 - Hintere Kette
-14. **Einbeinstand** - 13.11.2025 - Gleichgewicht und Sturzprophylaxe
-15. **Planke an der Wand** - 13.11.2025 - Rumpfstabilisation
-16. **Oberkörper heben (Bauch)** - 13.11.2025 - Bauchmuskulatur
-17. **Armheben mit Widerstand** - 13.11.2025 - Schulterkraft
-18. **Beinpendel seitlich** - 13.11.2025 - Hüftabduktoren
-19. **Standwaage** - 13.11.2025 - Balance und hintere Kette
-20. **Trizeps-Dips am Stuhl** - 13.11.2025 - Armrückseite
-21. **Seitlicher Unterarmstütz (modifiziert)** - 13.11.2025 - Seitliche Rumpfmuskulatur
-22. **Beckenlift** - 13.11.2025 - Gesäß und Oberschenkelrückseite
-23. **Ausfallschritt zurück** - 13.11.2025 - Beinkraft und Balance
-24. **Kniebeuge mit Stuhl** - 13.11.2025 - Sichere Beinübung
-25. **Wandliegestütze** - 13.11.2025 - Oberkörperkraft schonend
-26. **Rumpfrotation im Stand** - 13.11.2025 - Rumpfmobilisation
-27. **Fersen- und Zehenstand** - 13.11.2025 - Unterschenkel und Balance
-28. **Hampelmann (modifiziert)** - 13.11.2025 - Ganzkörper-Ausdauer
-29. **Knie zur Brust** - 13.11.2025 - Hüftmobilisation
-30. **Hüftkreisen** - 13.11.2025 - Hüftgelenksmobilisation
-31. **Seitneigung mit Armheben** - 13.11.2025 - Seitliche Mobilisation
-32. **Marschieren auf der Stelle** - 13.11.2025 - Ausdauer-Aufwärmen
-33. **Nackenrollen** - 13.11.2025 - Nackenmobilisation
-34. **Fußkreisen** - 13.11.2025 - Sprunggelenkmobilisation
-35. **Armkreisen** - 13.11.2025 - Schultermobilisation
-36. **Katze-Kuh** - 13.11.2025 - Wirbelsäulenmobilisation
-37. **Kniebeuge (Wandstütze)** - 13.11.2025 - Beinkraft mit Unterstützung
-38. **Schulterkreisen** - 13.11.2025 - Schultermobilisation
+1. **Stab-Rotation im Stand** - 02.12.2025 - Brustwirbelsäulen-Mobilisation mit Stab
+2. **Stab-Schultermobilisation** - 02.12.2025 - Schulterbeweglichkeit mit Stab
+3. **Stab-Seitneigung** - 02.12.2025 - Seitliche Rumpfkraft mit Stab
+4. **Stab-Brustdehnung** - 02.12.2025 - Brust- und Schulterdehnung mit Stab
+5. **Redondo-Ball Rückenmobilisation** - 02.12.2025 - Wirbelsäulen-Mobilisation
+6. **Redondo-Ball Beckenkippung** - 02.12.2025 - Beckenkontrolle und Core-Aktivierung
+7. **Redondo-Ball Rumpfstabilisation** - 02.12.2025 - Intensive Core-Kräftigung
+8. **Redondo-Ball Entspannung** - 02.12.2025 - Regeneration und Lockerung
+9. **Atemübung mit Armen** - 13.11.2025 - Entspannung und bewusste Atmung
+10. **Seitliche Rumpfdehnung im Sitzen** - 13.11.2025 - Seitliche Flanken dehnen
+11. **Brustdehnung an der Wand** - 13.11.2025 - Brust und vordere Schulter
+12. **Dehnung Hüftbeuger** - 13.11.2025 - Hüftbeugemuskulatur
+13. **Dehnung Oberschenkelrückseite** - 13.11.2025 - Hamstrings dehnen
+14. **Tandemstand** - 13.11.2025 - Gleichgewicht und Gangstabilität
+15. **Rumpfrotation mit Gewicht** - 13.11.2025 - Rotationskraft
+16. **Seitstütz Knie (modifiziert)** - 13.11.2025 - Seitliche Rumpfkraft
+17. **Wadenheben einbeinig** - 13.11.2025 - Wadenmuskulatur intensiv
+18. **Vogel-Hund (Vierfüßlerstand)** - 13.11.2025 - Koordination und Rumpfstabilität
+19. **Schulterbrücke einbeinig** - 13.11.2025 - Gesäßkraft intensiv
+20. **Seitlicher Ausfallschritt** - 13.11.2025 - Multidimensionale Beinkraft
+21. **Kreuzheben mit Wasserflasche** - 13.11.2025 - Hintere Kette
+22. **Einbeinstand** - 13.11.2025 - Gleichgewicht und Sturzprophylaxe
+23. **Planke an der Wand** - 13.11.2025 - Rumpfstabilisation
+24. **Oberkörper heben (Bauch)** - 13.11.2025 - Bauchmuskulatur
+25. **Armheben mit Widerstand** - 13.11.2025 - Schulterkraft
+26. **Beinpendel seitlich** - 13.11.2025 - Hüftabduktoren
+27. **Standwaage** - 13.11.2025 - Balance und hintere Kette
+28. **Trizeps-Dips am Stuhl** - 13.11.2025 - Armrückseite
+29. **Seitlicher Unterarmstütz (modifiziert)** - 13.11.2025 - Seitliche Rumpfmuskulatur
+30. **Beckenlift** - 13.11.2025 - Gesäß und Oberschenkelrückseite
+31. **Ausfallschritt zurück** - 13.11.2025 - Beinkraft und Balance
+32. **Kniebeuge mit Stuhl** - 13.11.2025 - Sichere Beinübung
+33. **Wandliegestütze** - 13.11.2025 - Oberkörperkraft schonend
+34. **Rumpfrotation im Stand** - 13.11.2025 - Rumpfmobilisation
+35. **Fersen- und Zehenstand** - 13.11.2025 - Unterschenkel und Balance
+36. **Hampelmann (modifiziert)** - 13.11.2025 - Ganzkörper-Ausdauer
+37. **Knie zur Brust** - 13.11.2025 - Hüftmobilisation
+38. **Hüftkreisen** - 13.11.2025 - Hüftgelenksmobilisation
+39. **Seitneigung mit Armheben** - 13.11.2025 - Seitliche Mobilisation
+40. **Marschieren auf der Stelle** - 13.11.2025 - Ausdauer-Aufwärmen
+41. **Nackenrollen** - 13.11.2025 - Nackenmobilisation
+42. **Fußkreisen** - 13.11.2025 - Sprunggelenkmobilisation
+43. **Armkreisen** - 13.11.2025 - Schultermobilisation
+44. **Katze-Kuh** - 13.11.2025 - Wirbelsäulenmobilisation
+45. **Kniebeuge (Wandstütze)** - 13.11.2025 - Beinkraft mit Unterstützung
+46. **Schulterkreisen** - 13.11.2025 - Schultermobilisation
 
 ---
 
@@ -522,5 +560,5 @@ Intensive, themenspezifische Übungen
 
 ---
 
-**Letzte Aktualisierung**: 13.11.2025  
+**Letzte Aktualisierung**: 02.12.2025
 **Nächste geplante Aktualisierung**: Bei neuen Übungen


### PR DESCRIPTION
## Summary
- Kombinierte Stab-und-Redondo-Stunde in zwei separate Stunden aufgeteilt
- Neue Stunde `gymnastikstab.md`: Fokus auf Mobilität, Haltung, Schulterbeweglichkeit
- Neue Stunde `redondo_ball.md`: Fokus auf Rumpfstabilität, Propriozeption
- 8 neue gerätespezifische Übungen hinzugefügt (4 Stab, 4 Redondo)
- Übungsindex aktualisiert

## Test plan
- [ ] Stunden-Dateien auf korrektes 45-Min-Schema prüfen
- [ ] Links zu Übungen verifizieren
- [ ] Knie- und Schulter-Alternativen vollständig

🤖 Generated with [Claude Code](https://claude.com/claude-code)