### PR TITLE
ci: Functions und Rules automatisch in CI deployen

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,13 +62,20 @@ jobs:
           PUBLIC_FIREBASE_APP_ID: ${{ steps.firebase-config.outputs.app_id }}
           PUBLIC_FIREBASE_MEASUREMENT_ID: ${{ steps.firebase-config.outputs.measurement_id }}
 
-      - name: Deploy to Firebase Hosting
-        uses: FirebaseExtended/action-hosting-deploy@v0
-        with:
-          repoToken: ${{ secrets.GITHUB_TOKEN }}
-          firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
-          channelId: live
-          projectId: rehasport-trainer
+      - name: Install Functions dependencies
+        run: npm ci
+        working-directory: functions
+
+      - name: Build Functions
+        run: npm run build
+        working-directory: functions
+
+      - name: Deploy to Firebase (Hosting + Functions + Rules)
+        run: |
+          echo '${{ secrets.FIREBASE_SERVICE_ACCOUNT }}' > /tmp/sa.json
+          export GOOGLE_APPLICATION_CREDENTIALS=/tmp/sa.json
+          firebase deploy --project rehasport-trainer
+          rm /tmp/sa.json
 
       - name: Get next version
         id: version

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,10 +72,7 @@ Hinweis: `VITE_*` wird aktuell im Code als Fallback akzeptiert.
 
 - Hosting-Ziel bleibt `site/dist`.
 - Rewrites fuer Detailpfade liegen in `firebase.json`.
-- CI-Workflow: `.github/workflows/release.yml` (deployed nur Hosting + erstellt Tag).
-- Cloud Functions und Firestore Rules muessen manuell deployed werden:
-  - `npx firebase deploy --only functions`
-  - `npx firebase deploy --only firestore:rules`
+- CI-Workflow: `.github/workflows/release.yml` (deployed Hosting + Functions + Rules + erstellt Tag).
 
 ## Dokumentation pflegen
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,8 +99,7 @@ firestore/
 
 ### Git Workflow
 - **Branch Protection:** Direct push zu `main` nicht moeglich - immer PR erstellen
-- **Release:** Feature-Branch -> PR -> Merge zu `main` (CI deployed automatisch Site + erstellt Tag)
-- **Manuell nach Release:** `npx firebase deploy --only functions,firestore:rules` (CI deployed nur Hosting)
+- **Release:** Feature-Branch -> PR -> Merge zu `main` (CI deployed alles + erstellt Tag)
 
 ### Cloud Functions (functions/src/index.ts)
 - **Region:** `europe-west1` fuer alle Functions

--- a/docs/deployment_und_betrieb.md
+++ b/docs/deployment_und_betrieb.md
@@ -101,23 +101,18 @@ Trigger:
 Pipeline:
 1. Checkout
 2. Node Setup
-3. `npm ci` in `site`
+3. `npm ci` in `site` + `functions`
 4. `npm test` in `site`
 5. Firebase CLI Setup
 6. Firebase Web SDK Config aus Projekt ziehen
 7. Frontend Build mit `PUBLIC_FIREBASE_*`-Variablen
-8. Deploy zu Firebase Hosting (`channelId: live`)
-9. Auto-Versionstag und GitHub Release
-
-**Wichtig:** Der CI-Workflow deployed nur Firebase Hosting. Cloud Functions und Firestore Rules muessen nach einem Release manuell deployed werden:
-
-```bash
-npx firebase deploy --only functions
-npx firebase deploy --only firestore:rules
-```
+8. Functions Build (`npm run build` in `functions`)
+9. Deploy zu Firebase (Hosting + Functions + Firestore Rules)
+10. Auto-Versionstag und GitHub Release
 
 ## Monitoring und Betriebshinweise
 
 - Der aktuelle Public-Frontend-Stand hat keine PWA-/Service-Worker-Logik.
 - Firestore Rules und Cloud Functions bleiben Teil der Gesamtplattform und werden ueber das Root-Projekt verwaltet.
 - Cloud Functions nutzen Fail-Closed Rate Limiting - bei Fehlern wird Zugriff verweigert.
+- CI deployed alles (Hosting + Functions + Rules) - kein manueller Deploy-Schritt noetig.

--- a/docs/entwicklungsrichtlinien.md
+++ b/docs/entwicklungsrichtlinien.md
@@ -65,7 +65,7 @@ npm run build
 - `main` ist Release-Zweig (auto deploy ueber Workflow)
 - kleine, reviewbare PRs
 - bei Routingaenderungen immer `firebase.json` mitziehen
-- CI deployed nur Hosting - Functions und Rules manuell deployen nach Merge
+- CI deployed alles (Hosting + Functions + Rules) bei Push auf `main`
 
 ## Doku-Disziplin
 


### PR DESCRIPTION
## Summary

- CI-Workflow deployed jetzt **alles** bei Push auf main: Hosting + Cloud Functions + Firestore Rules
- Kein manueller Deploy-Schritt mehr noetig nach Merge
- Docs entsprechend aktualisiert

## Aenderungen

### .github/workflows/release.yml
- `npm ci` + `npm run build` fuer functions/ ergaenzt
- `firebase deploy --project rehasport-trainer` statt nur Hosting-Action
- Service Account wird per GOOGLE_APPLICATION_CREDENTIALS gesetzt

### Dokumentation
- CLAUDE.md, AGENTS.md, deployment_und_betrieb.md, entwicklungsrichtlinien.md aktualisiert

## Test plan
- [ ] CI-Workflow durchlaufen lassen und pruefen ob Functions + Rules deployed werden

🤖 Generated with [Claude Code](https://claude.com/claude-code)