### PR TITLE
ci: Functions und Rules im CI-Workflow deployen

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,11 +70,19 @@ jobs:
         run: npm run build
         working-directory: functions
 
-      - name: Deploy to Firebase (Hosting + Functions + Rules)
+      - name: Deploy to Firebase Hosting
+        uses: FirebaseExtended/action-hosting-deploy@v0
+        with:
+          repoToken: ${{ secrets.GITHUB_TOKEN }}
+          firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
+          channelId: live
+          projectId: rehasport-trainer
+
+      - name: Deploy Functions and Firestore Rules
         run: |
           echo '${{ secrets.FIREBASE_SERVICE_ACCOUNT }}' > /tmp/sa.json
           export GOOGLE_APPLICATION_CREDENTIALS=/tmp/sa.json
-          firebase deploy --project rehasport-trainer
+          firebase deploy --only functions,firestore:rules --project rehasport-trainer
           rm /tmp/sa.json
 
       - name: Get next version


### PR DESCRIPTION
## Summary

- Hosting: weiterhin ueber bewehrte FirebaseExtended/action-hosting-deploy Action
- Functions + Rules: neu als separater Deploy-Step ueber Firebase CLI
- Functions werden gebaut (npm ci + npm run build) vor dem Deploy

**Voraussetzung:** Der Service Account braucht die Rolle "Service Account User" in Google Cloud IAM fuer Functions-Deploy.

## Test plan
- [ ] "Service Account User" Rolle zum SA hinzufuegen
- [ ] CI-Workflow durchlaufen lassen

🤖 Generated with [Claude Code](https://claude.com/claude-code)